### PR TITLE
Misc additions/changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [0.41.0] - 2017-03-25
 ### Added
-- `$showInHelp` attribute for commands, to set if it should be displayed in the `/help` command.
+- `$show_in_help` attribute for commands, to set if it should be displayed in the `/help` command.
 - Link to new Telegram group: `https://telegram.me/PHP_Telegram_Bot_Support`
 - Introduce change log.
 

--- a/examples/getUpdatesCLI.php
+++ b/examples/getUpdatesCLI.php
@@ -14,7 +14,7 @@ require __DIR__ . '/vendor/autoload.php';
 
 // Add you bot's API key and name
 $API_KEY = 'your_bot_api_key';
-$BOT_NAME = 'username_bot';
+$BOT_USERNAME = 'username_bot';
 
 // Define a path for your custom commands
 //$commands_path = __DIR__ . '/Commands/';
@@ -29,7 +29,7 @@ $mysql_credentials = [
 
 try {
     // Create Telegram API object
-    $telegram = new Longman\TelegramBot\Telegram($API_KEY, $BOT_NAME);
+    $telegram = new Longman\TelegramBot\Telegram($API_KEY, $BOT_USERNAME);
 
     // Error, Debug and Raw Update logging
     //Longman\TelegramBot\TelegramLog::initialize($your_external_monolog_instance);

--- a/examples/hook.php
+++ b/examples/hook.php
@@ -13,7 +13,7 @@ require __DIR__ . '/vendor/autoload.php';
 
 // Add you bot's API key and name
 $API_KEY = 'your_bot_api_key';
-$BOT_NAME = 'username_bot';
+$BOT_USERNAME = 'username_bot';
 
 // Define a path for your custom commands
 //$commands_path = __DIR__ . '/Commands/';
@@ -28,7 +28,7 @@ $BOT_NAME = 'username_bot';
 
 try {
     // Create Telegram API object
-    $telegram = new Longman\TelegramBot\Telegram($API_KEY, $BOT_NAME);
+    $telegram = new Longman\TelegramBot\Telegram($API_KEY, $BOT_USERNAME);
 
     // Error, Debug and Raw Update logging
     //Longman\TelegramBot\TelegramLog::initialize($your_external_monolog_instance);

--- a/examples/set.php
+++ b/examples/set.php
@@ -3,11 +3,12 @@
 require __DIR__ . '/vendor/autoload.php';
 
 $API_KEY = 'your_bot_api_key';
-$BOT_NAME = 'username_bot';
+$BOT_USERNAME = 'username_bot';
 $hook_url = 'https://yourdomain/path/to/hook.php';
+
 try {
     // Create Telegram API object
-    $telegram = new Longman\TelegramBot\Telegram($API_KEY, $BOT_NAME);
+    $telegram = new Longman\TelegramBot\Telegram($API_KEY, $BOT_USERNAME);
 
     // Set webhook
     $result = $telegram->setWebhook($hook_url);

--- a/examples/unset.php
+++ b/examples/unset.php
@@ -3,10 +3,11 @@
 require __DIR__ . '/vendor/autoload.php';
 
 $API_KEY = 'your_bot_api_key';
-$BOT_NAME = 'username_bot';
+$BOT_USERNAME = 'username_bot';
+
 try {
     // Create Telegram API object
-    $telegram = new Longman\TelegramBot\Telegram($API_KEY, $BOT_NAME);
+    $telegram = new Longman\TelegramBot\Telegram($API_KEY, $BOT_USERNAME);
 
     // Delete webhook
     $result = $telegram->deleteWebhook();

--- a/src/Entities/Entity.php
+++ b/src/Entities/Entity.php
@@ -12,6 +12,7 @@ namespace Longman\TelegramBot\Entities;
 
 use Exception;
 use Longman\TelegramBot\Entities\InlineQuery\InlineEntity;
+use Longman\TelegramBot\TelegramLog;
 use ReflectionObject;
 
 /**
@@ -21,8 +22,8 @@ use ReflectionObject;
  *
  * @link https://core.telegram.org/bots/api#available-types
  *
- * @method array  getRawData() Get the raw data passed to this entity
- * @method string getBotName() Return the bot name passed to this entity
+ * @method array  getRawData()     Get the raw data passed to this entity
+ * @method string getBotUsername() Return the bot name passed to this entity
  */
 abstract class Entity
 {
@@ -240,5 +241,18 @@ abstract class Entity
         }
 
         return ($is_username ? '@' : '') . $name;
+    }
+
+    /**
+     * Get Bot name
+     *
+     * @todo: Left for backwards compatibility, remove in the future
+     *
+     * @return string
+     */
+    public function getBotName()
+    {
+        TelegramLog::debug('Usage of deprecated method getBotName() detected, please use getBotUsername() instead!');
+        return $this->getBotUsername();
     }
 }

--- a/src/Entities/Entity.php
+++ b/src/Entities/Entity.php
@@ -29,14 +29,14 @@ abstract class Entity
     /**
      * Entity constructor.
      *
-     * @todo Get rid of the $bot_name, it shouldn't be here!
+     * @todo Get rid of the $bot_username, it shouldn't be here!
      *
      * @param array  $data
-     * @param string $bot_name
+     * @param string $bot_username
      *
      * @throws \Longman\TelegramBot\Exception\TelegramException
      */
-    public function __construct($data, $bot_name = '')
+    public function __construct($data, $bot_username = '')
     {
         //Make sure we're not raw_data inception-ing
         if (array_key_exists('raw_data', $data)) {
@@ -47,7 +47,7 @@ abstract class Entity
             $data['raw_data'] = $data;
         }
 
-        $data['bot_name'] = $bot_name;
+        $data['bot_username'] = $bot_username;
         $this->assignMemberVariables($data);
         $this->validate();
     }
@@ -142,7 +142,7 @@ abstract class Entity
                 $sub_entities = $this->subEntities();
 
                 if (isset($sub_entities[$property_name])) {
-                    return new $sub_entities[$property_name]($property, $this->getProperty('bot_name'));
+                    return new $sub_entities[$property_name]($property, $this->getProperty('bot_username'));
                 }
 
                 return $property;

--- a/src/Entities/Message.php
+++ b/src/Entities/Message.php
@@ -79,11 +79,11 @@ class Message extends Entity
      * Message constructor
      *
      * @param array  $data
-     * @param string $bot_name
+     * @param string $bot_username
      *
      * @throws \Longman\TelegramBot\Exception\TelegramException
      */
-    public function __construct(array $data, $bot_name = '')
+    public function __construct(array $data, $bot_username = '')
     {
         //Retro-compatibility
         if (isset($data['new_chat_participant'])) {
@@ -95,7 +95,7 @@ class Message extends Entity
             unset($data['left_chat_participant']);
         }
 
-        parent::__construct($data, $bot_name);
+        parent::__construct($data, $bot_username);
     }
 
     /**

--- a/src/Entities/ReplyToMessage.php
+++ b/src/Entities/ReplyToMessage.php
@@ -21,16 +21,16 @@ class ReplyToMessage extends Message
      * ReplyToMessage constructor.
      *
      * @param array  $data
-     * @param string $bot_name
+     * @param string $bot_username
      *
      * @throws \Longman\TelegramBot\Exception\TelegramException
      */
-    public function __construct(array $data, $bot_name = '')
+    public function __construct(array $data, $bot_username = '')
     {
         //As explained in the documentation
         //Reply to message can't contain other reply to message entities
         unset($data['reply_to_message']);
 
-        parent::__construct($data, $bot_name);
+        parent::__construct($data, $bot_username);
     }
 }

--- a/src/Entities/ServerResponse.php
+++ b/src/Entities/ServerResponse.php
@@ -26,11 +26,11 @@ class ServerResponse extends Entity
      * ServerResponse constructor.
      *
      * @param array  $data
-     * @param string $bot_name
+     * @param string $bot_username
      *
      * @throws \Longman\TelegramBot\Exception\TelegramException
      */
-    public function __construct(array $data, $bot_name)
+    public function __construct(array $data, $bot_username)
     {
         // Make sure we don't double-save the raw_data
         unset($data['raw_data']);
@@ -41,13 +41,13 @@ class ServerResponse extends Entity
 
         if ($is_ok && is_array($result)) {
             if ($this->isAssoc($result)) {
-                $data['result'] = $this->createResultObject($result, $bot_name);
+                $data['result'] = $this->createResultObject($result, $bot_username);
             } else {
-                $data['result'] = $this->createResultObjects($result, $bot_name);
+                $data['result'] = $this->createResultObjects($result, $bot_username);
             }
         }
 
-        parent::__construct($data, $bot_name);
+        parent::__construct($data, $bot_username);
     }
 
     /**
@@ -88,12 +88,12 @@ class ServerResponse extends Entity
      * Create and return the object of the received result
      *
      * @param array  $result
-     * @param string $bot_name
+     * @param string $bot_username
      *
      * @return \Longman\TelegramBot\Entities\Chat|\Longman\TelegramBot\Entities\ChatMember|\Longman\TelegramBot\Entities\File|\Longman\TelegramBot\Entities\Message|\Longman\TelegramBot\Entities\User|\Longman\TelegramBot\Entities\UserProfilePhotos|\Longman\TelegramBot\Entities\WebhookInfo
      * @throws \Longman\TelegramBot\Exception\TelegramException
      */
-    private function createResultObject($result, $bot_name)
+    private function createResultObject($result, $bot_username)
     {
         // We don't need to save the raw_data of the response object!
         $result['raw_data'] = null;
@@ -115,19 +115,19 @@ class ServerResponse extends Entity
         }
 
         //Response from sendMessage
-        return new Message($result, $bot_name);
+        return new Message($result, $bot_username);
     }
 
     /**
      * Create and return the objects array of the received result
      *
      * @param array  $result
-     * @param string $bot_name
+     * @param string $bot_username
      *
      * @return null|\Longman\TelegramBot\Entities\ChatMember[]|\Longman\TelegramBot\Entities\Update[]
      * @throws \Longman\TelegramBot\Exception\TelegramException
      */
-    private function createResultObjects($result, $bot_name)
+    private function createResultObjects($result, $bot_username)
     {
         $results = [];
         if (isset($result[0]['user'])) {
@@ -144,7 +144,7 @@ class ServerResponse extends Entity
                 // We don't need to save the raw_data of the response object!
                 $update['raw_data'] = null;
 
-                $results[] = new Update($update, $bot_name);
+                $results[] = new Update($update, $bot_username);
             }
         }
 

--- a/src/Request.php
+++ b/src/Request.php
@@ -315,12 +315,12 @@ class Request
     {
         self::ensureValidAction($action);
 
-        $bot_name = self::$telegram->getBotName();
+        $bot_username = self::$telegram->getBotUsername();
 
         if (defined('PHPUNIT_TESTSUITE')) {
             $fake_response = self::generateGeneralFakeServerResponse($data);
 
-            return new ServerResponse($fake_response, $bot_name);
+            return new ServerResponse($fake_response, $bot_username);
         }
 
         self::ensureNonEmptyData($data);
@@ -333,7 +333,7 @@ class Request
             throw new TelegramException('Telegram returned an invalid response! Please review your bot name and API key.');
         }
 
-        return new ServerResponse($response, $bot_name);
+        return new ServerResponse($response, $bot_username);
     }
 
     /**

--- a/src/Telegram.php
+++ b/src/Telegram.php
@@ -40,11 +40,11 @@ class Telegram
     protected $api_key = '';
 
     /**
-     * Telegram Bot name
+     * Telegram Bot username
      *
      * @var string
      */
-    protected $bot_name = '';
+    protected $bot_username = '';
 
     /**
      * Telegram Bot id
@@ -134,22 +134,22 @@ class Telegram
      * Telegram constructor.
      *
      * @param string $api_key
-     * @param string $bot_name
+     * @param string $bot_username
      *
      * @throws \Longman\TelegramBot\Exception\TelegramException
      */
-    public function __construct($api_key, $bot_name)
+    public function __construct($api_key, $bot_username)
     {
         if (empty($api_key)) {
             throw new TelegramException('API KEY not defined!');
         }
 
-        if (empty($bot_name)) {
+        if (empty($bot_username)) {
             throw new TelegramException('Bot Username not defined!');
         }
 
         $this->api_key  = $api_key;
-        $this->bot_name = $bot_name;
+        $this->bot_username = $bot_username;
 
         preg_match("/([0-9]*)\:.*/", $this->api_key, $matches);
         $this->bot_id = $matches[1];
@@ -319,7 +319,7 @@ class Telegram
                     'ok'          => false,
                     'description' => 'getUpdates needs MySQL connection!',
                 ],
-                $this->bot_name
+                $this->bot_username
             );
         }
 
@@ -369,7 +369,7 @@ class Telegram
             throw new TelegramException('Invalid JSON!');
         }
 
-        if ($response = $this->processUpdate(new Update($post, $this->bot_name))) {
+        if ($response = $this->processUpdate(new Update($post, $this->bot_username))) {
             return $response->isOk();
         }
 
@@ -733,9 +733,21 @@ class Telegram
      *
      * @return string
      */
+    public function getBotUsername()
+    {
+        return $this->bot_username;
+    }
+
+    /**
+     * Get Bot name
+     *  @todo: Left for backwards compatibility, remove in the future
+     *
+     * @return string
+     */
     public function getBotName()
     {
-        return $this->bot_name;
+        TelegramLog::debug('Usage of deprecated method getBotName() detected, please use getBotUsername() instead!');
+        return $this->getBotUsername();
     }
 
     /**

--- a/src/Telegram.php
+++ b/src/Telegram.php
@@ -143,16 +143,17 @@ class Telegram
         if (empty($api_key)) {
             throw new TelegramException('API KEY not defined!');
         }
+        preg_match('/(\d+)\:.+/', $api_key, $matches);
+        if (!isset($matches[1])) {
+            throw new TelegramException('Invalid API KEY defined!');
+        }
+        $this->bot_id  = $matches[1];
+        $this->api_key = $api_key;
 
         if (empty($bot_username)) {
             throw new TelegramException('Bot Username not defined!');
         }
-
-        $this->api_key  = $api_key;
         $this->bot_username = $bot_username;
-
-        preg_match("/([0-9]*)\:.*/", $this->api_key, $matches);
-        $this->bot_id = $matches[1];
 
         //Set default download and upload path
         $this->setDownloadPath(BASE_PATH . '/../Download');
@@ -740,7 +741,8 @@ class Telegram
 
     /**
      * Get Bot name
-     *  @todo: Left for backwards compatibility, remove in the future
+     *
+     * @todo: Left for backwards compatibility, remove in the future
      *
      * @return string
      */
@@ -860,7 +862,7 @@ class Telegram
      * Enable Botan.io integration
      *
      * @param  string $token
-     * @param  array $options
+     * @param  array  $options
      *
      * @return \Longman\TelegramBot\Telegram
      * @throws \Longman\TelegramBot\Exception\TelegramException
@@ -882,7 +884,7 @@ class Telegram
 
         return $this;
     }
-    
+
     /**
      * Run provided commands
      *
@@ -920,15 +922,15 @@ class Telegram
                         'from'       => [
                             'id'         => $bot_id,
                             'first_name' => $bot_name,
-                            'username'   => $bot_username
+                            'username'   => $bot_username,
                         ],
                         'date'       => time(),
                         'chat'       => [
                             'id'   => $bot_id,
                             'type' => 'private',
                         ],
-                        'text'       => $command
-                    ]
+                        'text'       => $command,
+                    ],
                 ]
             );
 

--- a/src/Telegram.php
+++ b/src/Telegram.php
@@ -47,6 +47,13 @@ class Telegram
     protected $bot_name = '';
 
     /**
+     * Telegram Bot id
+     *
+     * @var string
+     */
+    protected $bot_id = '';
+
+    /**
      * Raw request data (json) for webhook methods
      *
      * @var string
@@ -143,6 +150,9 @@ class Telegram
 
         $this->api_key  = $api_key;
         $this->bot_name = $bot_name;
+
+        preg_match("/([0-9]*)\:.*/", $this->api_key, $matches);
+        $this->bot_id = $matches[1];
 
         //Set default download and upload path
         $this->setDownloadPath(BASE_PATH . '/../Download');
@@ -726,6 +736,16 @@ class Telegram
     public function getBotName()
     {
         return $this->bot_name;
+    }
+
+    /**
+     * Get Bot Id
+     *
+     * @return string
+     */
+    public function getBotId()
+    {
+        return $this->bot_id;
     }
 
     /**

--- a/src/Telegram.php
+++ b/src/Telegram.php
@@ -30,7 +30,7 @@ class Telegram
      *
      * @var string
      */
-    protected $version = '0.40.1';
+    protected $version = '0.41.0';
 
     /**
      * Telegram API key

--- a/src/Telegram.php
+++ b/src/Telegram.php
@@ -143,7 +143,7 @@ class Telegram
         if (empty($api_key)) {
             throw new TelegramException('API KEY not defined!');
         }
-        preg_match('/(\d+)\:.+/', $api_key, $matches);
+        preg_match('/(\d+)\:[\w\-]+/', $api_key, $matches);
         if (!isset($matches[1])) {
             throw new TelegramException('Invalid API KEY defined!');
         }

--- a/tests/unit/Commands/CommandTest.php
+++ b/tests/unit/Commands/CommandTest.php
@@ -51,11 +51,11 @@ class CommandTest extends TestCase
     public function setUp()
     {
         //Default command object
-        $this->telegram = new Telegram('apikey', 'testbot');
+        $this->telegram = new Telegram(self::$dummy_api_key, 'testbot');
         $this->command_stub = $this->getMockForAbstractClass($this->command_namespace, [$this->telegram]);
 
         //Create separate command object that contain a command config
-        $this->telegram_with_config = new Telegram('apikey', 'testbot');
+        $this->telegram_with_config = new Telegram(self::$dummy_api_key, 'testbot');
         $this->telegram_with_config->setCommandConfig('command_name', ['config_key' => 'config_value']);
         $this->command_stub_with_config = $this->getMockBuilder($this->command_namespace)
              ->disableOriginalConstructor()

--- a/tests/unit/Commands/CommandTestCase.php
+++ b/tests/unit/Commands/CommandTestCase.php
@@ -37,7 +37,7 @@ class CommandTestCase extends TestCase
      */
     public function setUp()
     {
-        $this->telegram = new Telegram('apikey', 'testbot');
+        $this->telegram = new Telegram(self::$dummy_api_key, 'testbot');
         $this->telegram->addCommandsPath(BASE_COMMANDS_PATH . '/UserCommands');
 
         // Add custom commands dedicated to do some tests.

--- a/tests/unit/ConversationTest.php
+++ b/tests/unit/ConversationTest.php
@@ -39,7 +39,7 @@ class ConversationTest extends TestCase
             'password' => PHPUNIT_DB_PASS,
         ];
 
-        $this->telegram = new Telegram('apikey', 'testbot');
+        $this->telegram = new Telegram(self::$dummy_api_key, 'testbot');
         $this->telegram->enableMySql($credentials);
 
         //Make sure we start with an empty DB for each test.

--- a/tests/unit/TelegramTest.php
+++ b/tests/unit/TelegramTest.php
@@ -40,7 +40,7 @@ class TelegramTest extends TestCase
     */
     protected function setUp()
     {
-        $this->telegram = new Telegram('apikey', 'testbot');
+        $this->telegram = new Telegram(self::$dummy_api_key, 'testbot');
 
         // Create a few dummy custom commands paths.
         foreach ($this->custom_commands_paths as $custom_path) {
@@ -61,6 +61,7 @@ class TelegramTest extends TestCase
 
     /**
      * @expectedException \Longman\TelegramBot\Exception\TelegramException
+     * @expectedExceptionMessage API KEY not defined!
      */
     public function testNewInstanceWithoutApiKeyParam()
     {
@@ -69,20 +70,30 @@ class TelegramTest extends TestCase
 
     /**
      * @expectedException \Longman\TelegramBot\Exception\TelegramException
+     * @expectedExceptionMessage Invalid API KEY defined!
      */
-    public function testNewInstanceWithoutBotNameParam()
+    public function testNewInstanceWithInvalidApiKeyParam()
     {
-        new Telegram('apikey', null);
+        new Telegram('invalid-api-key-format', null);
+    }
+
+    /**
+     * @expectedException \Longman\TelegramBot\Exception\TelegramException
+     * @expectedExceptionMessage Bot Username not defined!
+     */
+    public function testNewInstanceWithoutBotUsernameParam()
+    {
+        new Telegram(self::$dummy_api_key, null);
     }
 
     public function testGetApiKey()
     {
-        $this->assertEquals('apikey', $this->telegram->getApiKey());
+        $this->assertEquals(self::$dummy_api_key, $this->telegram->getApiKey());
     }
 
-    public function testGetBotName()
+    public function testGetBotUsername()
     {
-        $this->assertEquals('testbot', $this->telegram->getBotName());
+        $this->assertEquals('testbot', $this->telegram->getBotUsername());
     }
 
     public function testEnableAdmins()

--- a/tests/unit/TestCase.php
+++ b/tests/unit/TestCase.php
@@ -12,6 +12,11 @@ namespace Longman\TelegramBot\Tests\Unit;
 
 class TestCase extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @var string
+     */
+    public static $dummy_api_key = '123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11';
+
     protected function skip64BitTest()
     {
         if (PHP_INT_SIZE === 4) {


### PR DESCRIPTION
Add `getBotId()` method to `Telegram` object.
Regex extracting the id from the API key should be fine.

Rename `bot_name` variables (and similar) into `bot_username` to prevent confusion.

Unit Tests need a fix.