### PR TITLE
Another small additions and changes

### DIFF
--- a/examples/cron.php
+++ b/examples/cron.php
@@ -64,7 +64,9 @@ try {
     //$telegram->setUploadPath('../Upload');
 
     // Requests Limiter (tries to prevent reaching Telegram API limits)
+    // Second argument are options
     $telegram->enableLimiter();
+    //$telegram->enableLimiter(['interval' => 0.5);
 
     // Run user selected commands
     $telegram->runCommands($commands);

--- a/examples/cron.php
+++ b/examples/cron.php
@@ -64,7 +64,7 @@ try {
     //$telegram->setUploadPath('../Upload');
 
     // Requests Limiter (tries to prevent reaching Telegram API limits)
-    // Second argument are options
+    // First argument are options
     $telegram->enableLimiter();
     //$telegram->enableLimiter(['interval' => 0.5);
 

--- a/examples/getUpdatesCLI.php
+++ b/examples/getUpdatesCLI.php
@@ -70,7 +70,7 @@ try {
     //$telegram->enableBotan('your_token', ['timeout' => 3]);
 
     // Requests Limiter (tries to prevent reaching Telegram API limits)
-    // Second argument are options
+    // First argument are options
     $telegram->enableLimiter();
     //$telegram->enableLimiter(['interval' => 0.5);
 

--- a/examples/getUpdatesCLI.php
+++ b/examples/getUpdatesCLI.php
@@ -70,7 +70,9 @@ try {
     //$telegram->enableBotan('your_token', ['timeout' => 3]);
 
     // Requests Limiter (tries to prevent reaching Telegram API limits)
+    // Second argument are options
     $telegram->enableLimiter();
+    //$telegram->enableLimiter(['interval' => 0.5);
 
     // Handle telegram getUpdates request
     $serverResponse = $telegram->handleGetUpdates();

--- a/examples/hook.php
+++ b/examples/hook.php
@@ -69,7 +69,9 @@ try {
     //$telegram->enableBotan('your_token', ['timeout' => 3]);
 
     // Requests Limiter (tries to prevent reaching Telegram API limits)
+    // Second argument are options
     $telegram->enableLimiter();
+    //$telegram->enableLimiter(['interval' => 0.5);
 
     // Handle telegram webhook request
     $telegram->handle();

--- a/examples/hook.php
+++ b/examples/hook.php
@@ -69,7 +69,7 @@ try {
     //$telegram->enableBotan('your_token', ['timeout' => 3]);
 
     // Requests Limiter (tries to prevent reaching Telegram API limits)
-    // Second argument are options
+    // First argument are options
     $telegram->enableLimiter();
     //$telegram->enableLimiter(['interval' => 0.5);
 

--- a/src/DB.php
+++ b/src/DB.php
@@ -191,7 +191,7 @@ class DB
                 $sql .= ' WHERE `id` = :id';
             }
 
-            $sql.= ' ORDER BY `id` DESC';
+            $sql .= ' ORDER BY `id` DESC';
 
             if ($limit !== null) {
                 $sql .= ' LIMIT :limit';

--- a/src/DB.php
+++ b/src/DB.php
@@ -173,7 +173,7 @@ class DB
      * Fetch update(s) from DB
      *
      * @param int $limit Limit the number of updates to fetch
-     * @param int $id Check for unique update id
+     * @param int $id    Check for unique update id
      *
      * @return array|bool Fetched data or false if not connected
      * @throws \Longman\TelegramBot\Exception\TelegramException
@@ -482,7 +482,7 @@ class DB
         $update_id   = $update->getUpdateId();
         $update_type = $update->getUpdateType();
 
-        if (count(self::selectTelegramUpdate(1, $update->getUpdateId())) == 1) {
+        if (count(self::selectTelegramUpdate(1, $update->getUpdateId())) === 1) {
             throw new TelegramException('Duplicate update received!');
         }
 

--- a/src/Telegram.php
+++ b/src/Telegram.php
@@ -131,6 +131,13 @@ class Telegram
     protected $botan_enabled = false;
 
     /**
+     * Check if runCommands() is running in this session
+     *
+     * @var boolean
+     */
+    protected $run_commands = false;
+
+    /**
      * Telegram constructor.
      *
      * @param string $api_key
@@ -896,6 +903,7 @@ class Telegram
             throw new TelegramException('No command(s) provided!');
         }
 
+        $this->run_commands = true;
         $this->botan_enabled = false;   // Force disable Botan.io integration, we don't want to track self-executed commands!
 
         $result = Request::getMe()->getResult();
@@ -924,8 +932,8 @@ class Telegram
                         ],
                         'date'       => time(),
                         'chat'       => [
-                            'id'   => $bot_id,
-                            'type' => 'private',
+                            'id'         => $bot_id,
+                            'type'       => 'private',
                         ],
                         'text'       => $command,
                     ],
@@ -934,5 +942,15 @@ class Telegram
 
             $this->executeCommand($this->update->getMessage()->getCommand());
         }
+    }
+
+    /**
+     * Is this session initiated by runCommands()
+     *
+     * @return string
+     */
+    public function isRunCommands()
+    {
+        return $this->run_commands;
     }
 }

--- a/src/Telegram.php
+++ b/src/Telegram.php
@@ -882,10 +882,14 @@ class Telegram
 
     /**
      * Enable requests limiter
+     *
+     * @param  array  $options
+     * 
+     * @return \Longman\TelegramBot\Telegram
      */
-    public function enableLimiter()
+    public function enableLimiter(array $options = [])
     {
-        Request::setLimiter(true);
+        Request::setLimiter(true, $options);
 
         return $this;
     }

--- a/src/Telegram.php
+++ b/src/Telegram.php
@@ -884,7 +884,7 @@ class Telegram
      * Enable requests limiter
      *
      * @param  array  $options
-     * 
+     *
      * @return \Longman\TelegramBot\Telegram
      */
     public function enableLimiter(array $options = [])

--- a/src/Telegram.php
+++ b/src/Telegram.php
@@ -951,7 +951,7 @@ class Telegram
     /**
      * Is this session initiated by runCommands()
      *
-     * @return string
+     * @return bool
      */
     public function isRunCommands()
     {


### PR DESCRIPTION
- Add isRunCommands()

Discussed here https://github.com/php-telegram-bot/core/issues/444
Couldnt find a better name for this function.

- Add optional parameter 'interval' to modify check interval for request limiter

By default there is 1 second delay between a check, which is fine but in some cases developer might want the delay to be slightly smaller (or higher!).

Important Notes:
Settings this to 0.5 will make the check every 0.5 second, this should improve bot resposiveness but can cause a slow down if database server is slow. 
Any value below 1 can cause requests actually reach Telegram API's limits - scenario where previous request was sent just before the next second pops in and another request is instantly served, if this happens too many times in a row Telegram API will issue a block, this is fine for small bursts.

- Prevent serving duplicate updates, throw exception instead

Issues with Telegram Bot API servers recently, attempt to prevent duplicated replies...

Also figured out how to get telegram_update's date:
This will select all records older than `2017-04-15 13:32:25`:
```
SELECT * FROM `telegram_update` WHERE
(`message_id` IS NOT NULL AND `message_id` IN (SELECT f.id FROM `message` f WHERE `date` < '2017-04-15 13:32:25')) OR 
(`edited_message_id` IS NOT NULL AND `edited_message_id` IN (SELECT f.id FROM `edited_message` f WHERE `edit_date` < '2017-04-15 13:32:25')) OR 
(`inline_query_id` IS NOT NULL AND `inline_query_id` IN (SELECT f.id FROM `inline_query` f WHERE `created_at` < '2017-04-15 13:32:25')) OR 
(`chosen_inline_result_id` IS NOT NULL AND `chosen_inline_result_id` IN (SELECT f.id FROM `chosen_inline_result` f WHERE `created_at` < '2017-04-15 13:32:25')) OR 
(`callback_query_id` IS NOT NULL AND `callback_query_id` IN (SELECT f.id FROM `callback_query` f WHERE `created_at` < '2017-04-15 13:32:25'))
```

(might be good idea to have a wiki article containing useful queries like this!?)