### PR TITLE
Make bot username variable not required

### DIFF
--- a/src/Telegram.php
+++ b/src/Telegram.php
@@ -320,6 +320,10 @@ class Telegram
      */
     public function handleGetUpdates($limit = null, $timeout = null)
     {
+        if (empty($this->bot_username)) {
+            throw new TelegramException('Bot Username is not defined!');
+        }
+
         if (!DB::isDbConnected()) {
             return new ServerResponse(
                 [
@@ -365,6 +369,10 @@ class Telegram
      */
     public function handle()
     {
+        if (empty($this->bot_username)) {
+            throw new TelegramException('Bot Username is not defined!');
+        }
+
         $this->input = Request::getInput();
 
         if (empty($this->input)) {
@@ -406,10 +414,6 @@ class Telegram
     public function processUpdate(Update $update)
     {
         $this->update = $update;
-
-        if (empty($this->bot_username)) {
-            throw new TelegramException('Bot Username is not defined!');
-        }
 
         //If all else fails, it's a generic message.
         $command = 'genericmessage';

--- a/src/Telegram.php
+++ b/src/Telegram.php
@@ -145,7 +145,7 @@ class Telegram
      *
      * @throws \Longman\TelegramBot\Exception\TelegramException
      */
-    public function __construct($api_key, $bot_username)
+    public function __construct($api_key, $bot_username = '')
     {
         if (empty($api_key)) {
             throw new TelegramException('API KEY not defined!');
@@ -157,10 +157,9 @@ class Telegram
         $this->bot_id  = $matches[1];
         $this->api_key = $api_key;
 
-        if (empty($bot_username)) {
-            throw new TelegramException('Bot Username not defined!');
+        if (!empty($bot_username)) {
+            $this->bot_username = $bot_username;
         }
-        $this->bot_username = $bot_username;
 
         //Set default download and upload path
         $this->setDownloadPath(BASE_PATH . '/../Download');
@@ -407,6 +406,10 @@ class Telegram
     public function processUpdate(Update $update)
     {
         $this->update = $update;
+
+        if (empty($this->bot_username)) {
+            throw new TelegramException('Bot Username is not defined!');
+        }
 
         //If all else fails, it's a generic message.
         $command = 'genericmessage';

--- a/tests/unit/TelegramTest.php
+++ b/tests/unit/TelegramTest.php
@@ -71,15 +71,6 @@ class TelegramTest extends TestCase
         new Telegram('invalid-api-key-format', null);
     }
 
-    /**
-     * @expectedException \Longman\TelegramBot\Exception\TelegramException
-     * @expectedExceptionMessage Bot Username not defined!
-     */
-    public function testNewInstanceWithoutBotUsernameParam()
-    {
-        new Telegram(self::$dummy_api_key, null);
-    }
-
     public function testGetApiKey()
     {
         $this->assertEquals(self::$dummy_api_key, $this->telegram->getApiKey());


### PR DESCRIPTION
Make bot username variable not required (useful for developers using this library only to send requests to Telegram api).
Trying to handle a webhook or getUpdates without bot username will result with exception.

_Wait for merge after merging https://github.com/php-telegram-bot/core/pull/474_

~~@noplanman What do you think about the change I did in https://github.com/php-telegram-bot/core/commit/0ad36434ebfdba0c67a11fdb6f937acdaa16f887#diff-c677a2f49b92b068a764b7b31f669c38R186, it could essentially be useless change but what came to my mind what if `/cmd@`, will this result with `$split_cmd[1]` being empty which would equal empty bot username? I think it should not return true since its '===' check but who knows...~~