### PR TITLE
Send a document as content data using Psr7 stream.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Exclamation symbols (:exclamation:) note something of importance e.g. breaking c
 
 ## [Unreleased]
 ### Added
+- Documents can be sent by providing its contents via Psr7 stream (as opposed to passing a file path).
 ### Changed
 ### Deprecated
 ### Removed

--- a/src/Request.php
+++ b/src/Request.php
@@ -201,7 +201,7 @@ class Request
 
         //Reformat data array in multipart way if it contains a resource
         foreach ($data as $key => $item) {
-            $has_resource |= is_resource($item);
+            $has_resource |= (is_resource($item) || $item instanceof \GuzzleHttp\Psr7\Stream);
             $multipart[] = ['name' => $key, 'contents' => $item];
         }
         if ($has_resource) {


### PR DESCRIPTION
All credit for this PR goes to @pavlyuts
Sorry it took so long!

This is basically a copy of #329 and closes #325.

Copying the original PR message here to explain:

---

Makes it possible to send all kind of files from memory, not from file on disk by usage of PSR-7 streams.

All we need is to create PSR-7 stream and pass it as a part of `$data` to any of the `sendXXXX` methods. The patch fixes exec method to handle request as multipart for both cases: file resource and stream.

The key should be set in accordance to the API call type: `document`, `photo`, `audio`, etc. using the corresponding `sendDocument`, `sendPhoto`, `sendAudio`, etc. methods.

PSR-7 metadata `uri` must contain filename.

Code example:

```php
$chat_id = 1234;
$caption = 'File send from memory!';
$stream = \GuzzleHttp\Psr7\stream_for(
    'File contents here!',
    ['metadata' => ['uri' => 'filename.ext']]
);

$data = [
    'chat_id' => $chat_id,
    'caption' => $caption,
    'document' => $stream,
];

Request::sendDocument($data);
```

The example will send as document the file named 'filename.ext' containing 'File contents here!'.
