### PR TITLE
Allow setting a custom Guzzle HTTP Client for requests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Exclamation symbols (:exclamation:) note something of importance e.g. breaking c
 ## [Unreleased]
 ### Added
 - Documents can be sent by providing its contents via Psr7 stream (as opposed to passing a file path).
+- Allow setting a custom Guzzle HTTP Client for requests (#511).
 ### Changed
 ### Deprecated
 ### Removed

--- a/src/Request.php
+++ b/src/Request.php
@@ -104,16 +104,32 @@ class Request
      *
      * @param \Longman\TelegramBot\Telegram $telegram
      *
-     * @throws \Longman\TelegramBot\Exception\TelegramException
+     * @throws TelegramException
      */
     public static function initialize(Telegram $telegram)
     {
-        if (is_object($telegram)) {
-            self::$telegram = $telegram;
-            self::$client   = new Client(['base_uri' => self::$api_base_uri]);
-        } else {
-            throw new TelegramException('Telegram pointer is empty!');
+        if (!($telegram instanceof Telegram)) {
+            throw new TelegramException('Invalid Telegram pointer!');
         }
+
+        self::$telegram = $telegram;
+        self::setClient(new Client(['base_uri' => self::$api_base_uri]));
+    }
+
+    /**
+     * Set a custom Guzzle HTTP Client object
+     *
+     * @param Client $client
+     *
+     * @throws TelegramException
+     */
+    public static function setClient(Client $client)
+    {
+        if (!($client instanceof Client)) {
+            throw new TelegramException('Invalid GuzzleHttp\Client pointer!');
+        }
+
+        self::$client = $client;
     }
 
     /**


### PR DESCRIPTION
After setting the `$telegram` object, it is very easy to set a custom Guzzle HTTP Client to allow a custom API URL or simply to modify various parameters (like SSL verification):
```php
Request::setClient(new \GuzzleHttp\Client([
    'base_uri' => 'https://149.154.167.197',
    'verify'   => false,
]));
```

Fixes #507 
Fixes #511 