### PR TITLE
Up and download folders are undefined by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Exclamation symbols (:exclamation:) note something of importance e.g. breaking c
 ### Changed
 ### Deprecated
 ### Removed
+- [:exclamation:][unreleased-bc-up-download-directory] Upload and download directories are not set any more by default and must be set manually.
 ### Fixed
 ### Security
 
@@ -26,7 +27,7 @@ Exclamation symbols (:exclamation:) note something of importance e.g. breaking c
 ### Removed
 - All examples have been moved to a [dedicated repository](https://github.com/php-telegram-bot/example-bot).
 ### Fixed
-- [:exclamation:](https://github.com/php-telegram-bot/core/wiki/Breaking-backwards-compatibility#0440) Format of Update content type using `$update->getUpdateContent()`.
+- [:exclamation:][0.44.0-bc-update-content-type] Format of Update content type using `$update->getUpdateContent()`.
 
 ## [0.43.0] - 2017-04-17
 ### Added
@@ -101,3 +102,6 @@ Exclamation symbols (:exclamation:) note something of importance e.g. breaking c
 - Logging improvements to Botan integration.
 ### Deprecated
 - Move `hideKeyboard` to `removeKeyboard`.
+
+[unreleased-bc-up-download-directory]: https://github.com/php-telegram-bot/core/wiki/Breaking-backwards-compatibility#unreleased
+[0.44.0-bc-update-content-type]: https://github.com/php-telegram-bot/core/wiki/Breaking-backwards-compatibility#update-getupdatecontent

--- a/src/Commands/AdminCommands/DebugCommand.php
+++ b/src/Commands/AdminCommands/DebugCommand.php
@@ -63,8 +63,8 @@ class DebugCommand extends AdminCommand
         $debug_info = [];
 
         $debug_info[] = sprintf('*TelegramBot version:* `%s`', $this->telegram->getVersion());
-        $debug_info[] = sprintf('*Download path:* `%s`', $this->telegram->getDownloadPath());
-        $debug_info[] = sprintf('*Upload path:* `%s`', $this->telegram->getUploadPath());
+        $debug_info[] = sprintf('*Download path:* `%s`', $this->telegram->getDownloadPath() ?: '`_Not set_`');
+        $debug_info[] = sprintf('*Upload path:* `%s`', $this->telegram->getUploadPath() ?: '`_Not set_`');
 
         // Commands paths.
         $debug_info[] = '*Commands paths:*';

--- a/src/Request.php
+++ b/src/Request.php
@@ -278,8 +278,12 @@ class Request
      */
     public static function downloadFile(File $file)
     {
+        if (empty($download_path = self::$telegram->getDownloadPath())) {
+            throw new TelegramException('Download path not set!');
+        }
+
         $tg_file_path = $file->getFilePath();
-        $file_path    = self::$telegram->getDownloadPath() . '/' . $tg_file_path;
+        $file_path    = $download_path . '/' . $tg_file_path;
 
         $file_dir = dirname($file_path);
         //For safety reasons, first try to create the directory, then check that it exists.

--- a/src/Telegram.php
+++ b/src/Telegram.php
@@ -161,10 +161,6 @@ class Telegram
             $this->bot_username = $bot_username;
         }
 
-        //Set default download and upload path
-        $this->setDownloadPath(BASE_PATH . '/../Download');
-        $this->setUploadPath(BASE_PATH . '/../Upload');
-
         //Add default system commands path
         $this->addCommandsPath(BASE_COMMANDS_PATH . '/SystemCommands');
 


### PR DESCRIPTION
They must now be set manually via `$telegram->setUploadPath(...)` and `$telegram->setDownloadPath(...)`.

Using `Request::downloadFile(...)` without setting the download path now throws an exception!

Close #483 