### PR TITLE
Callbacks can be added to be executed when callback queries are called.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Exclamation symbols (:exclamation:) note something of importance e.g. breaking c
 
 ## [Unreleased]
 ### Added
+- Callbacks can be added to be executed when callback queries are called.
 ### Changed
 ### Deprecated
 ### Removed

--- a/src/Commands/SystemCommands/CallbackqueryCommand.php
+++ b/src/Commands/SystemCommands/CallbackqueryCommand.php
@@ -19,6 +19,11 @@ use Longman\TelegramBot\Request;
 class CallbackqueryCommand extends SystemCommand
 {
     /**
+     * @var callable[]
+     */
+    protected static $callbacks = [];
+
+    /**
      * @var string
      */
     protected $name = 'callbackquery';
@@ -46,6 +51,21 @@ class CallbackqueryCommand extends SystemCommand
         //$query_id       = $callback_query->getId();
         //$query_data     = $callback_query->getData();
 
+        // Call all registered callbacks.
+        foreach (self::$callbacks as $callback) {
+            $callback($this->getUpdate()->getCallbackQuery());
+        }
+
         return Request::answerCallbackQuery(['callback_query_id' => $this->getUpdate()->getCallbackQuery()->getId()]);
+    }
+
+    /**
+     * Add a new callback handler for callback queries.
+     *
+     * @param $callback
+     */
+    public static function addCallbackHandler($callback)
+    {
+        self::$callbacks[] = $callback;
     }
 }


### PR DESCRIPTION
This allows adding callback hooks to CallbackqueryCommand:

e.g. in `hook.php` when setting up the lib:
```php
CallbackqueryCommand::addCallbackHandler(function (CallbackQuery $query) {
    if ($query->getFrom()->getUsername() === 'noplanman') {
        // Do something with this callback, but only when requested by @noplanman
    }
});
```

Any number of callback handlers can be added like this. All of them get run when a callback is being executed, so each callback function needs to do its own checks to handle the proper calls.

@jacklul I've been thinking of ways to extend this, but I'd like to keep it as simple as possible for now, and I feel this is already quite powerful in itself and allows users to very easily add their own custom code to callbacks. What do you think?