### PR TITLE
Bot API 3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ Exclamation symbols (:exclamation:) note something of importance e.g. breaking c
 ## [Unreleased]
 ### Added
 - Callbacks can be added to be executed when callback queries are called.
+- New Bot API 3.1 changes (#550).
 ### Changed
+- [:exclamation:][unreleased-bc-request-class-refactor] Big refactor of the `Request` class, removing most custom method implementations.
 ### Deprecated
 ### Removed
 ### Fixed
@@ -122,6 +124,7 @@ Exclamation symbols (:exclamation:) note something of importance e.g. breaking c
 ### Deprecated
 - Move `hideKeyboard` to `removeKeyboard`.
 
+[unreleased-bc-request-class-refactor]: https://github.com/php-telegram-bot/core/wiki/Breaking-backwards-compatibility#request-class-refactor
 [0.45.0-bc-remove-deprecated-methods]: https://github.com/php-telegram-bot/core/wiki/Breaking-backwards-compatibility#remove-deprecated-methods
 [0.45.0-bc-chats-params-array]: https://github.com/php-telegram-bot/core/wiki/Breaking-backwards-compatibility#chats-params-array
 [0.45.0-bc-up-download-directory]: https://github.com/php-telegram-bot/core/wiki/Breaking-backwards-compatibility#up-download-directory

--- a/src/Entities/Chat.php
+++ b/src/Entities/Chat.php
@@ -15,23 +15,39 @@ namespace Longman\TelegramBot\Entities;
  *
  * @link https://core.telegram.org/bots/api#chat
  *
- * @property int    $id                              Unique identifier for this chat. This number may be greater than 32 bits and some programming languages may have difficulty/silent defects in interpreting it. But it smaller than 52 bits, so a signed 64 bit integer or double-precision float type are safe for storing this identifier.
- * @property string $type                            Type of chat, can be either "private", "group", "supergroup" or "channel"
- * @property string $title                           Optional. Title, for channels and group chats
- * @property string $username                        Optional. Username, for private chats, supergroups and channels if available
- * @property string $first_name                      Optional. First name of the other party in a private chat
- * @property string $last_name                       Optional. Last name of the other party in a private chat
- * @property bool   $all_members_are_administrators  Optional. True if a group has ‘All Members Are Admins’ enabled.
- * @method   int    getId()                          Unique identifier for this chat. This number may be greater than 32 bits and some programming languages may have difficulty/silent defects in interpreting it. But it smaller than 52 bits, so a signed 64 bit integer or double-precision float type are safe for storing this identifier.
- * @method   string getType()                        Type of chat, can be either "private ", "group", "supergroup" or "channel"
- * @method   string getTitle()                       Optional. Title, for channels and group chats
- * @method   string getUsername()                    Optional. Username, for private chats, supergroups and channels if available
- * @method   string getFirstName()                   Optional. First name of the other party in a private chat
- * @method   string getLastName()                    Optional. Last name of the other party in a private chat
- * @method   bool   getAllMembersAreAdministrators() Optional. True if a group has ‘All Members Are Admins’ enabled.
+ * @property int       $id                              Unique identifier for this chat. This number may be greater than 32 bits and some programming languages may have difficulty/silent defects in interpreting it. But it smaller than 52 bits, so a signed 64 bit integer or double-precision float type are safe for storing this identifier.
+ * @property string    $type                            Type of chat, can be either "private", "group", "supergroup" or "channel"
+ * @property string    $title                           Optional. Title, for channels and group chats
+ * @property string    $username                        Optional. Username, for private chats, supergroups and channels if available
+ * @property string    $first_name                      Optional. First name of the other party in a private chat
+ * @property string    $last_name                       Optional. Last name of the other party in a private chat
+ * @property bool      $all_members_are_administrators  Optional. True if a group has ‘All Members Are Admins’ enabled.
+ * @property ChatPhoto $photo                           Optional. Chat photo. Returned only in getChat.
+ * @property string    $description                     Optional. Description, for supergroups and channel chats. Returned only in getChat.
+ * @property string    $invite_link                     Optional. Chat invite link, for supergroups and channel chats. Returned only in getChat.
+ * @method   int       getId()                          Unique identifier for this chat. This number may be greater than 32 bits and some programming languages may have difficulty/silent defects in interpreting it. But it smaller than 52 bits, so a signed 64 bit integer or double-precision float type are safe for storing this identifier.
+ * @method   string    getType()                        Type of chat, can be either "private ", "group", "supergroup" or "channel"
+ * @method   string    getTitle()                       Optional. Title, for channels and group chats
+ * @method   string    getUsername()                    Optional. Username, for private chats, supergroups and channels if available
+ * @method   string    getFirstName()                   Optional. First name of the other party in a private chat
+ * @method   string    getLastName()                    Optional. Last name of the other party in a private chat
+ * @method   bool      getAllMembersAreAdministrators() Optional. True if a group has ‘All Members Are Admins’ enabled.
+ * @method   ChatPhoto getPhoto()                       Optional. Chat photo. Returned only in getChat.
+ * @method   string    getDescription()                 Optional. Description, for supergroups and channel chats. Returned only in getChat.
+ * @method   string    getInviteLink()                  Optional. Chat invite link, for supergroups and channel chats. Returned only in getChat.
  */
 class Chat extends Entity
 {
+    /**
+     * {@inheritdoc}
+     */
+    public function subEntities()
+    {
+        return [
+            'photo' => ChatPhoto::class,
+        ];
+    }
+
     public function __construct($data)
     {
         parent::__construct($data);

--- a/src/Entities/ChatMember.php
+++ b/src/Entities/ChatMember.php
@@ -15,8 +15,22 @@ namespace Longman\TelegramBot\Entities;
  *
  * @link https://core.telegram.org/bots/api#chatmember
  *
- * @method User   getUser()   Information about the user.
- * @method string getStatus() The member's status in the chat. Can be "creator", "administrator", "member", "left" or "kicked"
+ * @method User   getUser()                  Information about the user
+ * @method string getStatus()                The member's status in the chat. Can be “creator”, “administrator”, “member”, “restricted”, “left” or “kicked”
+ * @method int    getUntilDate()             Optional. Restricted and kicked only. Date when restrictions will be lifted for this user, unix time
+ * @method bool   getCanBeEdited()           Optional. Administrators only. True, if the bot is allowed to edit administrator privileges of that user
+ * @method bool   getCanChangeInfo()         Optional. Administrators only. True, if the administrator can change the chat title, photo and other settings
+ * @method bool   getCanPostMessages()       Optional. Administrators only. True, if the administrator can post in the channel, channels only
+ * @method bool   getCanEditMessages()       Optional. Administrators only. True, if the administrator can edit messages of other users, channels only
+ * @method bool   getCanDeleteMessages()     Optional. Administrators only. True, if the administrator can delete messages of other users
+ * @method bool   getCanInviteUsers()        Optional. Administrators only. True, if the administrator can invite new users to the chat
+ * @method bool   getCanRestrictMembers()    Optional. Administrators only. True, if the administrator can restrict, ban or unban chat members
+ * @method bool   getCanPinMessages()        Optional. Administrators only. True, if the administrator can pin messages, supergroups only
+ * @method bool   getCanPromoteMembers()     Optional. Administrators only. True, if the administrator can add new administrators with a subset of his own privileges or demote administrators that he has promoted, directly or indirectly (promoted by administrators that were appointed by the user)
+ * @method bool   getCanSendMessages()       Optional. Restricted only. True, if the user can send text messages, contacts, locations and venues
+ * @method bool   getCanSendMediaMessages()  Optional. Restricted only. True, if the user can send audios, documents, photos, videos, video notes and voice notes, implies can_send_messages
+ * @method bool   getCanSendOtherMessages()  Optional. Restricted only. True, if the user can send animations, games, stickers and use inline bots, implies can_send_media_messages
+ * @method bool   getCanAddWebPagePreviews() Optional. Restricted only. True, if user may add web page previews to his messages, implies can_send_media_messages
  */
 class ChatMember extends Entity
 {

--- a/src/Entities/ChatPhoto.php
+++ b/src/Entities/ChatPhoto.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * This file is part of the TelegramBot package.
+ *
+ * (c) Avtandil Kikabidze aka LONGMAN <akalongman@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Longman\TelegramBot\Entities;
+
+/**
+ * Class ChatPhoto
+ *
+ * @link https://core.telegram.org/bots/api#chatphoto
+ *
+ * @method string getSmallFileId() Unique file identifier of small(160x160) chat photo. This file_id can be used only for photo download.
+ * @method string getBigFileId()   Unique file identifier of big(640x640) chat photo. This file_id can be used only for photo download.
+ */
+class ChatPhoto extends Entity
+{
+
+}

--- a/src/Request.php
+++ b/src/Request.php
@@ -85,8 +85,10 @@ class Request
         'getUserProfilePhotos',
         'getFile',
         'kickChatMember',
-        'leaveChat',
         'unbanChatMember',
+        'restrictChatMember',
+        'promoteChatMember',
+        'leaveChat',
         'getChat',
         'getChatAdministrators',
         'getChatMember',
@@ -701,21 +703,6 @@ class Request
     }
 
     /**
-     * Use this method for your bot to leave a group, supergroup or channel. Returns True on success.
-     *
-     * @link https://core.telegram.org/bots/api#leavechat
-     *
-     * @param array $data
-     *
-     * @return \Longman\TelegramBot\Entities\ServerResponse
-     * @throws \Longman\TelegramBot\Exception\TelegramException
-     */
-    public static function leaveChat(array $data)
-    {
-        return self::send('leaveChat', $data);
-    }
-
-    /**
      * Use this method to unban a previously kicked user in a supergroup. Returns True on success.
      *
      * The user will not return to the group automatically, but will be able to join via link, etc.
@@ -731,6 +718,57 @@ class Request
     public static function unbanChatMember(array $data)
     {
         return self::send('unbanChatMember', $data);
+    }
+
+    /**
+     * Use this method to restrict a user in a supergroup. Returns True on success.
+     *
+     * The bot must be an administrator in the supergroup for this to work and must have the appropriate admin rights.
+     * Pass True for all boolean parameters to lift restrictions from a user.
+     *
+     * @link https://core.telegram.org/bots/api#restrictchatmember
+     *
+     * @param array $data
+     *
+     * @return \Longman\TelegramBot\Entities\ServerResponse
+     * @throws \Longman\TelegramBot\Exception\TelegramException
+     */
+    public static function restrictChatMember(array $data)
+    {
+        return self::send('restrictChatMember', $data);
+    }
+
+    /**
+     * Use this method to promote or demote a user in a supergroup or a channel. Returns True on success.
+     *
+     * The bot must be an administrator in the chat for this to work and must have the appropriate admin rights.
+     * Pass False for all boolean parameters to demote a user.
+     *
+     * @link https://core.telegram.org/bots/api#promotechatmember
+     *
+     * @param array $data
+     *
+     * @return \Longman\TelegramBot\Entities\ServerResponse
+     * @throws \Longman\TelegramBot\Exception\TelegramException
+     */
+    public static function promoteChatMember(array $data)
+    {
+        return self::send('promoteChatMember', $data);
+    }
+
+    /**
+     * Use this method for your bot to leave a group, supergroup or channel. Returns True on success.
+     *
+     * @link https://core.telegram.org/bots/api#leavechat
+     *
+     * @param array $data
+     *
+     * @return \Longman\TelegramBot\Entities\ServerResponse
+     * @throws \Longman\TelegramBot\Exception\TelegramException
+     */
+    public static function leaveChat(array $data)
+    {
+        return self::send('leaveChat', $data);
     }
 
     /**

--- a/src/Request.php
+++ b/src/Request.php
@@ -19,10 +19,47 @@ use Longman\TelegramBot\Exception\TelegramException;
 /**
  * Class Request
  *
+ * @method static ServerResponse getUpdates(array $data)             Use this method to receive incoming updates using long polling (wiki). An Array of Update objects is returned.
  * @method static ServerResponse setWebhook(array $data)             Use this method to specify a url and receive incoming updates via an outgoing webhook. Whenever there is an update for the bot, we will send an HTTPS POST request to the specified url, containing a JSON-serialized Update. In case of an unsuccessful request, we will give up after a reasonable amount of attempts. Returns true.
  * @method static ServerResponse deleteWebhook()                     Use this method to remove webhook integration if you decide to switch back to getUpdates. Returns True on success. Requires no parameters.
  * @method static ServerResponse getWebhookInfo()                    Use this method to get current webhook status. Requires no parameters. On success, returns a WebhookInfo object. If the bot is using getUpdates, will return an object with the url field empty.
  * @method static ServerResponse getMe()                             A simple method for testing your bot's auth token. Requires no parameters. Returns basic information about the bot in form of a User object.
+ * @method static ServerResponse forwardMessage(array $data)         Use this method to forward messages of any kind. On success, the sent Message is returned.
+ * @method static ServerResponse sendPhoto(array $data)              Use this method to send photos. On success, the sent Message is returned.
+ * @method static ServerResponse sendAudio(array $data)              Use this method to send audio files, if you want Telegram clients to display them in the music player. Your audio must be in the .mp3 format. On success, the sent Message is returned. Bots can currently send audio files of up to 50 MB in size, this limit may be changed in the future.
+ * @method static ServerResponse sendDocument(array $data)           Use this method to send general files. On success, the sent Message is returned. Bots can currently send files of any type of up to 50 MB in size, this limit may be changed in the future.
+ * @method static ServerResponse sendSticker(array $data)            Use this method to send .webp stickers. On success, the sent Message is returned.
+ * @method static ServerResponse sendVideo(array $data)              Use this method to send video files, Telegram clients support mp4 videos (other formats may be sent as Document). On success, the sent Message is returned. Bots can currently send video files of up to 50 MB in size, this limit may be changed in the future.
+ * @method static ServerResponse sendVoice(array $data)              Use this method to send audio files, if you want Telegram clients to display the file as a playable voice message. For this to work, your audio must be in an .ogg file encoded with OPUS (other formats may be sent as Audio or Document). On success, the sent Message is returned. Bots can currently send voice messages of up to 50 MB in size, this limit may be changed in the future.
+ * @method static ServerResponse sendVideoNote(array $data)          Use this method to send video messages. On success, the sent Message is returned.
+ * @method static ServerResponse sendLocation(array $data)           Use this method to send point on the map. On success, the sent Message is returned.
+ * @method static ServerResponse sendVenue(array $data)              Use this method to send information about a venue. On success, the sent Message is returned.
+ * @method static ServerResponse sendContact(array $data)            Use this method to send phone contacts. On success, the sent Message is returned.
+ * @method static ServerResponse sendChatAction(array $data)         Use this method when you need to tell the user that something is happening on the bot's side. The status is set for 5 seconds or less (when a message arrives from your bot, Telegram clients clear its typing status). Returns True on success.
+ * @method static ServerResponse getUserProfilePhotos(array $data)   Use this method to get a list of profile pictures for a user. Returns a UserProfilePhotos object.
+ * @method static ServerResponse getFile(array $data)                Use this method to get basic info about a file and prepare it for downloading. For the moment, bots can download files of up to 20MB in size. On success, a File object is returned. The file can then be downloaded via the link https://api.telegram.org/file/bot<token>/<file_path>, where <file_path> is taken from the response. It is guaranteed that the link will be valid for at least 1 hour. When the link expires, a new one can be requested by calling getFile again.
+ * @method static ServerResponse kickChatMember(array $data)         Use this method to kick a user from a group, a supergroup or a channel. In the case of supergroups and channels, the user will not be able to return to the group on their own using invite links, etc., unless unbanned first. The bot must be an administrator in the chat for this to work and must have the appropriate admin rights. Returns True on success.
+ * @method static ServerResponse unbanChatMember(array $data)        Use this method to unban a previously kicked user in a supergroup or channel. The user will not return to the group or channel automatically, but will be able to join via link, etc. The bot must be an administrator for this to work. Returns True on success.
+ * @method static ServerResponse restrictChatMember(array $data)     Use this method to restrict a user in a supergroup. The bot must be an administrator in the supergroup for this to work and must have the appropriate admin rights. Pass True for all boolean parameters to lift restrictions from a user. Returns True on success.
+ * @method static ServerResponse promoteChatMember(array $data)      Use this method to promote or demote a user in a supergroup or a channel. The bot must be an administrator in the chat for this to work and must have the appropriate admin rights. Pass False for all boolean parameters to demote a user. Returns True on success.
+ * @method static ServerResponse exportChatInviteLink(array $data)   Use this method to export an invite link to a supergroup or a channel. The bot must be an administrator in the chat for this to work and must have the appropriate admin rights. Returns exported invite link as String on success.
+ * @method static ServerResponse setChatPhoto(array $data)           Use this method to set a new profile photo for the chat. Photos can't be changed for private chats. The bot must be an administrator in the chat for this to work and must have the appropriate admin rights. Returns True on success.
+ * @method static ServerResponse deleteChatPhoto(array $data)        Use this method to delete a chat photo. Photos can't be changed for private chats. The bot must be an administrator in the chat for this to work and must have the appropriate admin rights. Returns True on success.
+ * @method static ServerResponse setChatTitle(array $data)           Use this method to change the title of a chat. Titles can't be changed for private chats. The bot must be an administrator in the chat for this to work and must have the appropriate admin rights. Returns True on success.
+ * @method static ServerResponse setChatDescription(array $data)     Use this method to change the description of a supergroup or a channel. The bot must be an administrator in the chat for this to work and must have the appropriate admin rights. Returns True on success.
+ * @method static ServerResponse pinChatMessage(array $data)         Use this method to pin a message in a supergroup. The bot must be an administrator in the chat for this to work and must have the appropriate admin rights. Returns True on success.
+ * @method static ServerResponse unpinChatMessage(array $data)       Use this method to unpin a message in a supergroup chat. The bot must be an administrator in the chat for this to work and must have the appropriate admin rights. Returns True on success.
+ * @method static ServerResponse leaveChat(array $data)              Use this method for your bot to leave a group, supergroup or channel. Returns True on success.
+ * @method static ServerResponse getChat(array $data)                Use this method to get up to date information about the chat (current name of the user for one-on-one conversations, current username of a user, group or channel, etc.). Returns a Chat object on success.
+ * @method static ServerResponse getChatAdministrators(array $data)  Use this method to get a list of administrators in a chat. On success, returns an Array of ChatMember objects that contains information about all chat administrators except other bots. If the chat is a group or a supergroup and no administrators were appointed, only the creator will be returned.
+ * @method static ServerResponse getChatMembersCount(array $data)    Use this method to get the number of members in a chat. Returns Int on success.
+ * @method static ServerResponse getChatMember(array $data)          Use this method to get information about a member of a chat. Returns a ChatMember object on success.
+ * @method static ServerResponse answerCallbackQuery(array $data)    Use this method to send answers to callback queries sent from inline keyboards. The answer will be displayed to the user as a notification at the top of the chat screen or as an alert. On success, True is returned.
+ * @method static ServerResponse answerInlineQuery(array $data)      Use this method to send answers to an inline query. On success, True is returned.
+ * @method static ServerResponse editMessageText(array $data)        Use this method to edit text and game messages sent by the bot or via the bot (for inline bots). On success, if edited message is sent by the bot, the edited Message is returned, otherwise True is returned.
+ * @method static ServerResponse editMessageCaption(array $data)     Use this method to edit captions of messages sent by the bot or via the bot (for inline bots). On success, if edited message is sent by the bot, the edited Message is returned, otherwise True is returned.
+ * @method static ServerResponse editMessageReplyMarkup(array $data) Use this method to edit only the reply markup of messages sent by the bot or via the bot (for inline bots). On success, if edited message is sent by the bot, the edited Message is returned, otherwise True is returned.
+ * @method static ServerResponse deleteMessage(array $data)          Use this method to delete a message, including service messages, with certain limitations. Returns True on success.
  */
 class Request
 {
@@ -91,6 +128,7 @@ class Request
         'sendSticker',
         'sendVideo',
         'sendVoice',
+        'sendVideoNote',
         'sendLocation',
         'sendVenue',
         'sendContact',
@@ -101,11 +139,18 @@ class Request
         'unbanChatMember',
         'restrictChatMember',
         'promoteChatMember',
+        'exportChatInviteLink',
+        'setChatPhoto',
+        'deleteChatPhoto',
+        'setChatTitle',
+        'setChatDescription',
+        'pinChatMessage',
+        'unpinChatMessage',
         'leaveChat',
         'getChat',
         'getChatAdministrators',
-        'getChatMember',
         'getChatMembersCount',
+        'getChatMember',
         'answerCallbackQuery',
         'answerInlineQuery',
         'editMessageText',
@@ -442,22 +487,6 @@ class Request
     }
 
     /**
-     * Assign an encoded file to a data array
-     *
-     * @param array  $data
-     * @param string $field
-     * @param string $file
-     *
-     * @throws \Longman\TelegramBot\Exception\TelegramException
-     */
-    private static function assignEncodedFile(&$data, $field, $file)
-    {
-        if ($file !== null && $file !== '') {
-            $data[$field] = self::encodeFile($file);
-        }
-    }
-
-    /**
      * Use this method to send text messages. On success, the sent Message is returned
      *
      * @link https://core.telegram.org/bots/api#sendmessage
@@ -484,494 +513,20 @@ class Request
     }
 
     /**
-     * Use this method to forward messages of any kind. On success, the sent Message is returned
+     * Any statically called method should be relayed to the `send` method.
      *
-     * @link https://core.telegram.org/bots/api#forwardmessage
-     *
-     * @param array $data
-     *
-     * @return \Longman\TelegramBot\Entities\ServerResponse
-     * @throws \Longman\TelegramBot\Exception\TelegramException
-     */
-    public static function forwardMessage(array $data)
-    {
-        return self::send('forwardMessage', $data);
-    }
-
-    /**
-     * Use this method to send photos. On success, the sent Message is returned
-     *
-     * @link https://core.telegram.org/bots/api#sendphoto
-     *
+     * @param string $action
      * @param array  $data
-     * @param string $file
      *
      * @return \Longman\TelegramBot\Entities\ServerResponse
      * @throws \Longman\TelegramBot\Exception\TelegramException
      */
-    public static function sendPhoto(array $data, $file = null)
+    public static function __callStatic($action, array $data)
     {
-        self::assignEncodedFile($data, 'photo', $file);
+        // Make sure to add the action being called as the first parameter to be passed.
+        array_unshift($data, $action);
 
-        return self::send('sendPhoto', $data);
-    }
-
-    /**
-     * Use this method to send audio files
-     *
-     * Your audio must be in the .mp3 format. On success, the sent Message is returned.
-     * Bots can currently send audio files of up to 50 MB in size, this limit may be changed in the future.
-     * For sending voice messages, use the sendVoice method instead.
-     *
-     * @link https://core.telegram.org/bots/api#sendaudio
-     *
-     * @param array  $data
-     * @param string $file
-     *
-     * @return \Longman\TelegramBot\Entities\ServerResponse
-     * @throws \Longman\TelegramBot\Exception\TelegramException
-     */
-    public static function sendAudio(array $data, $file = null)
-    {
-        self::assignEncodedFile($data, 'audio', $file);
-
-        return self::send('sendAudio', $data);
-    }
-
-    /**
-     * Use this method to send general files. On success, the sent Message is returned.
-     *
-     * Bots can currently send files of any type of up to 50 MB in size, this limit may be changed in the future.
-     *
-     * @link https://core.telegram.org/bots/api#senddocument
-     *
-     * @param array  $data
-     * @param string $file
-     *
-     * @return \Longman\TelegramBot\Entities\ServerResponse
-     * @throws \Longman\TelegramBot\Exception\TelegramException
-     */
-    public static function sendDocument(array $data, $file = null)
-    {
-        self::assignEncodedFile($data, 'document', $file);
-
-        return self::send('sendDocument', $data);
-    }
-
-    /**
-     * Use this method to send .webp stickers. On success, the sent Message is returned.
-     *
-     * @link https://core.telegram.org/bots/api#sendsticker
-     *
-     * @param array  $data
-     * @param string $file
-     *
-     * @return \Longman\TelegramBot\Entities\ServerResponse
-     * @throws \Longman\TelegramBot\Exception\TelegramException
-     */
-    public static function sendSticker(array $data, $file = null)
-    {
-        self::assignEncodedFile($data, 'sticker', $file);
-
-        return self::send('sendSticker', $data);
-    }
-
-    /**
-     * Use this method to send video files. On success, the sent Message is returned.
-     *
-     * Telegram clients support mp4 videos (other formats may be sent as Document).
-     * Bots can currently send video files of up to 50 MB in size, this limit may be changed in the future.
-     *
-     * @link https://core.telegram.org/bots/api#sendvideo
-     *
-     * @param array  $data
-     * @param string $file
-     *
-     * @return \Longman\TelegramBot\Entities\ServerResponse
-     * @throws \Longman\TelegramBot\Exception\TelegramException
-     */
-    public static function sendVideo(array $data, $file = null)
-    {
-        self::assignEncodedFile($data, 'video', $file);
-
-        return self::send('sendVideo', $data);
-    }
-
-    /**
-     * Use this method to send audio files. On success, the sent Message is returned.
-     *
-     * Telegram clients will display the file as a playable voice message.
-     * For this to work, your audio must be in an .ogg file encoded with OPUS (other formats may be sent as Audio or Document).
-     * Bots can currently send voice messages of up to 50 MB in size, this limit may be changed in the future.
-     *
-     * @link https://core.telegram.org/bots/api#sendvoice
-     *
-     * @param array  $data
-     * @param string $file
-     *
-     * @return \Longman\TelegramBot\Entities\ServerResponse
-     * @throws \Longman\TelegramBot\Exception\TelegramException
-     */
-    public static function sendVoice(array $data, $file = null)
-    {
-        self::assignEncodedFile($data, 'voice', $file);
-
-        return self::send('sendVoice', $data);
-    }
-
-    /**
-     * Use this method to send point on the map. On success, the sent Message is returned.
-     *
-     * @link https://core.telegram.org/bots/api#sendlocation
-     *
-     * @param array $data
-     *
-     * @return \Longman\TelegramBot\Entities\ServerResponse
-     * @throws \Longman\TelegramBot\Exception\TelegramException
-     */
-    public static function sendLocation(array $data)
-    {
-        return self::send('sendLocation', $data);
-    }
-
-    /**
-     * Use this method to send information about a venue. On success, the sent Message is returned.
-     *
-     * @link https://core.telegram.org/bots/api#sendvenue
-     *
-     * @param array $data
-     *
-     * @return \Longman\TelegramBot\Entities\ServerResponse
-     * @throws \Longman\TelegramBot\Exception\TelegramException
-     */
-    public static function sendVenue(array $data)
-    {
-        return self::send('sendVenue', $data);
-    }
-
-    /**
-     * Use this method to send phone contacts. On success, the sent Message is returned.
-     *
-     * @link https://core.telegram.org/bots/api#sendcontact
-     *
-     * @param array $data
-     *
-     * @return \Longman\TelegramBot\Entities\ServerResponse
-     * @throws \Longman\TelegramBot\Exception\TelegramException
-     */
-    public static function sendContact(array $data)
-    {
-        return self::send('sendContact', $data);
-    }
-
-    /**
-     * Use this method when you need to tell the user that something is happening on the bot's side.
-     *
-     * The status is set for 5 seconds or less.
-     * (when a message arrives from your bot, Telegram clients clear its typing status)
-     *
-     * @link https://core.telegram.org/bots/api#sendchataction
-     *
-     * @param array $data
-     *
-     * @return \Longman\TelegramBot\Entities\ServerResponse
-     * @throws \Longman\TelegramBot\Exception\TelegramException
-     */
-    public static function sendChatAction(array $data)
-    {
-        return self::send('sendChatAction', $data);
-    }
-
-    /**
-     * Use this method to get a list of profile pictures for a user. Returns a UserProfilePhotos object.
-     *
-     * @param array $data
-     *
-     * @return \Longman\TelegramBot\Entities\ServerResponse
-     * @throws \Longman\TelegramBot\Exception\TelegramException
-     */
-    public static function getUserProfilePhotos(array $data)
-    {
-        return self::send('getUserProfilePhotos', $data);
-    }
-
-    /**
-     * Use this method to get basic info about a file and prepare it for downloading. On success, a File object is returned.
-     *
-     * For the moment, bots can download files of up to 20MB in size.
-     * The file can then be downloaded via the link https://api.telegram.org/file/bot<token>/<file_path>,
-     * where <file_path> is taken from the response.
-     * It is guaranteed that the link will be valid for at least 1 hour.
-     * When the link expires, a new one can be requested by calling getFile again.
-     *
-     * @link https://core.telegram.org/bots/api#getfile
-     *
-     * @param array $data
-     *
-     * @return \Longman\TelegramBot\Entities\ServerResponse
-     * @throws \Longman\TelegramBot\Exception\TelegramException
-     */
-    public static function getFile(array $data)
-    {
-        return self::send('getFile', $data);
-    }
-
-    /**
-     * Use this method to kick a user from a group or a supergroup. Returns True on success.
-     *
-     * In the case of supergroups, the user will not be able to return to the group on their own using invite links, etc., unless unbanned first.
-     * The bot must be an administrator in the group for this to work.
-     *
-     * @link https://core.telegram.org/bots/api#kickchatmember
-     *
-     * @param array $data
-     *
-     * @return \Longman\TelegramBot\Entities\ServerResponse
-     * @throws \Longman\TelegramBot\Exception\TelegramException
-     */
-    public static function kickChatMember(array $data)
-    {
-        return self::send('kickChatMember', $data);
-    }
-
-    /**
-     * Use this method to unban a previously kicked user in a supergroup. Returns True on success.
-     *
-     * The user will not return to the group automatically, but will be able to join via link, etc.
-     * The bot must be an administrator in the group for this to work.
-     *
-     * @link https://core.telegram.org/bots/api#unbanchatmember
-     *
-     * @param array $data
-     *
-     * @return \Longman\TelegramBot\Entities\ServerResponse
-     * @throws \Longman\TelegramBot\Exception\TelegramException
-     */
-    public static function unbanChatMember(array $data)
-    {
-        return self::send('unbanChatMember', $data);
-    }
-
-    /**
-     * Use this method to restrict a user in a supergroup. Returns True on success.
-     *
-     * The bot must be an administrator in the supergroup for this to work and must have the appropriate admin rights.
-     * Pass True for all boolean parameters to lift restrictions from a user.
-     *
-     * @link https://core.telegram.org/bots/api#restrictchatmember
-     *
-     * @param array $data
-     *
-     * @return \Longman\TelegramBot\Entities\ServerResponse
-     * @throws \Longman\TelegramBot\Exception\TelegramException
-     */
-    public static function restrictChatMember(array $data)
-    {
-        return self::send('restrictChatMember', $data);
-    }
-
-    /**
-     * Use this method to promote or demote a user in a supergroup or a channel. Returns True on success.
-     *
-     * The bot must be an administrator in the chat for this to work and must have the appropriate admin rights.
-     * Pass False for all boolean parameters to demote a user.
-     *
-     * @link https://core.telegram.org/bots/api#promotechatmember
-     *
-     * @param array $data
-     *
-     * @return \Longman\TelegramBot\Entities\ServerResponse
-     * @throws \Longman\TelegramBot\Exception\TelegramException
-     */
-    public static function promoteChatMember(array $data)
-    {
-        return self::send('promoteChatMember', $data);
-    }
-
-    /**
-     * Use this method for your bot to leave a group, supergroup or channel. Returns True on success.
-     *
-     * @link https://core.telegram.org/bots/api#leavechat
-     *
-     * @param array $data
-     *
-     * @return \Longman\TelegramBot\Entities\ServerResponse
-     * @throws \Longman\TelegramBot\Exception\TelegramException
-     */
-    public static function leaveChat(array $data)
-    {
-        return self::send('leaveChat', $data);
-    }
-
-    /**
-     * Use this method to get up to date information about the chat (current name of the user for one-on-one conversations, current username of a user, group or channel, etc.). Returns a Chat object on success.
-     *
-     * @todo add get response in ServerResponse.php?
-     *
-     * @link https://core.telegram.org/bots/api#getchat
-     *
-     * @param array $data
-     *
-     * @return \Longman\TelegramBot\Entities\ServerResponse
-     * @throws \Longman\TelegramBot\Exception\TelegramException
-     */
-    public static function getChat(array $data)
-    {
-        return self::send('getChat', $data);
-    }
-
-    /**
-     * Use this method to get a list of administrators in a chat.
-     *
-     * On success, returns an Array of ChatMember objects that contains information about all chat administrators except other bots.
-     * If the chat is a group or a supergroup and no administrators were appointed, only the creator will be returned.
-     *
-     * @todo add get response in ServerResponse.php?
-     *
-     * @link https://core.telegram.org/bots/api#getchatadministrators
-     *
-     * @param array $data
-     *
-     * @return \Longman\TelegramBot\Entities\ServerResponse
-     * @throws \Longman\TelegramBot\Exception\TelegramException
-     */
-    public static function getChatAdministrators(array $data)
-    {
-        return self::send('getChatAdministrators', $data);
-    }
-
-    /**
-     * Use this method to get the number of members in a chat. Returns Int on success.
-     *
-     * @todo add get response in ServerResponse.php?
-     *
-     * @link https://core.telegram.org/bots/api#getchatmemberscount
-     *
-     * @param array $data
-     *
-     * @return \Longman\TelegramBot\Entities\ServerResponse
-     * @throws \Longman\TelegramBot\Exception\TelegramException
-     */
-    public static function getChatMembersCount(array $data)
-    {
-        return self::send('getChatMembersCount', $data);
-    }
-
-    /**
-     * Use this method to get information about a member of a chat. Returns a ChatMember object on success.
-     *
-     * @todo add get response in ServerResponse.php?
-     *
-     * @link https://core.telegram.org/bots/api#getchatmember
-     *
-     * @param array $data
-     *
-     * @return \Longman\TelegramBot\Entities\ServerResponse
-     * @throws \Longman\TelegramBot\Exception\TelegramException
-     */
-    public static function getChatMember(array $data)
-    {
-        return self::send('getChatMember', $data);
-    }
-
-    /**
-     * Use this method to send answers to callback queries sent from inline keyboards. On success, True is returned.
-     *
-     * The answer will be displayed to the user as a notification at the top of the chat screen or as an alert.
-     *
-     * @link https://core.telegram.org/bots/api#answercallbackquery
-     *
-     * @param array $data
-     *
-     * @return \Longman\TelegramBot\Entities\ServerResponse
-     * @throws \Longman\TelegramBot\Exception\TelegramException
-     */
-    public static function answerCallbackQuery(array $data)
-    {
-        return self::send('answerCallbackQuery', $data);
-    }
-
-    /**
-     * Get updates
-     *
-     * @link https://core.telegram.org/bots/api#getupdates
-     *
-     * @param array $data
-     *
-     * @return \Longman\TelegramBot\Entities\ServerResponse
-     * @throws \Longman\TelegramBot\Exception\TelegramException
-     */
-    public static function getUpdates(array $data)
-    {
-        return self::send('getUpdates', $data);
-    }
-
-    /**
-     * Use this method to edit text and game messages sent by the bot or via the bot (for inline bots).
-     *
-     * On success, if edited message is sent by the bot, the edited Message is returned, otherwise True is returned.
-     *
-     * @link https://core.telegram.org/bots/api#editmessagetext
-     *
-     * @param array $data
-     *
-     * @return \Longman\TelegramBot\Entities\ServerResponse
-     * @throws \Longman\TelegramBot\Exception\TelegramException
-     */
-    public static function editMessageText(array $data)
-    {
-        return self::send('editMessageText', $data);
-    }
-
-    /**
-     * Use this method to edit captions of messages sent by the bot or via the bot (for inline bots).
-     *
-     * On success, if edited message is sent by the bot, the edited Message is returned, otherwise True is returned.
-     *
-     * @link https://core.telegram.org/bots/api#editmessagecaption
-     *
-     * @param array $data
-     *
-     * @return \Longman\TelegramBot\Entities\ServerResponse
-     * @throws \Longman\TelegramBot\Exception\TelegramException
-     */
-    public static function editMessageCaption(array $data)
-    {
-        return self::send('editMessageCaption', $data);
-    }
-
-    /**
-     * Use this method to edit only the reply markup of messages sent by the bot or via the bot (for inline bots).
-     *
-     * On success, if edited message is sent by the bot, the edited Message is returned, otherwise True is returned.
-     *
-     * @link https://core.telegram.org/bots/api#editmessagereplymarkup
-     *
-     * @param array $data
-     *
-     * @return \Longman\TelegramBot\Entities\ServerResponse
-     * @throws \Longman\TelegramBot\Exception\TelegramException
-     */
-    public static function editMessageReplyMarkup(array $data)
-    {
-        return self::send('editMessageReplyMarkup', $data);
-    }
-
-    /**
-     * Use this method to send answers to an inline query. On success, True is returned.
-     *
-     * No more than 50 results per query are allowed.
-     *
-     * @link https://core.telegram.org/bots/api#answerinlinequery
-     *
-     * @param array $data
-     *
-     * @return \Longman\TelegramBot\Entities\ServerResponse
-     * @throws \Longman\TelegramBot\Exception\TelegramException
-     */
-    public static function answerInlineQuery(array $data)
-    {
-        return self::send('answerInlineQuery', $data);
+        return call_user_func_array('static::send', $data);
     }
 
     /**
@@ -1070,12 +625,15 @@ class Request
                 'sendSticker',
                 'sendVideo',
                 'sendVoice',
+                'sendVideoNote',
                 'sendLocation',
                 'sendVenue',
                 'sendContact',
                 'editMessageText',
                 'editMessageCaption',
                 'editMessageReplyMarkup',
+                'setChatTitle',
+                'setChatDescription',
             ];
 
             $chat_id = isset($data['chat_id']) ? $data['chat_id'] : null;
@@ -1106,40 +664,5 @@ class Request
                 DB::insertTelegramRequest($action, $data);
             }
         }
-    }
-
-    /**
-     * Use this method to delete either bot's messages or messages of other users if the bot is admin of the group.
-     *
-     * On success, true is returned.
-     *
-     * @link https://core.telegram.org/bots/api#deletemessage
-     *
-     * @param array $data
-     *
-     * @return \Longman\TelegramBot\Entities\ServerResponse
-     * @throws \Longman\TelegramBot\Exception\TelegramException
-     */
-    public static function deleteMessage(array $data)
-    {
-        return self::send('deleteMessage', $data);
-    }
-
-    /**
-     * Use this method to send video notes. On success, the sent Message is returned.
-     *
-     * @link https://core.telegram.org/bots/api#sendvideonote
-     *
-     * @param array  $data
-     * @param string $file
-     *
-     * @return \Longman\TelegramBot\Entities\ServerResponse
-     * @throws \Longman\TelegramBot\Exception\TelegramException
-     */
-    public static function sendVideoNote(array $data, $file = null)
-    {
-        self::assignEncodedFile($data, 'video_note', $file);
-
-        return self::send('sendVideoNote', $data);
     }
 }

--- a/src/Request.php
+++ b/src/Request.php
@@ -19,6 +19,7 @@ use Longman\TelegramBot\Exception\TelegramException;
 /**
  * Class Request
  *
+ * @method static ServerResponse setWebhook(array $data)             Use this method to specify a url and receive incoming updates via an outgoing webhook. Whenever there is an update for the bot, we will send an HTTPS POST request to the specified url, containing a JSON-serialized Update. In case of an unsuccessful request, we will give up after a reasonable amount of attempts. Returns true.
  * @method static ServerResponse deleteWebhook()                     Use this method to remove webhook integration if you decide to switch back to getUpdates. Returns True on success. Requires no parameters.
  * @method static ServerResponse getWebhookInfo()                    Use this method to get current webhook status. Requires no parameters. On success, returns a WebhookInfo object. If the bot is using getUpdates, will return an object with the url field empty.
  * @method static ServerResponse getMe()                             A simple method for testing your bot's auth token. Requires no parameters. Returns basic information about the bot in form of a User object.
@@ -344,9 +345,9 @@ class Request
      * @return resource
      * @throws \Longman\TelegramBot\Exception\TelegramException
      */
-    protected static function encodeFile($file)
+    public static function encodeFile($file)
     {
-        $fp = fopen($file, 'r');
+        $fp = fopen($file, 'rb');
         if ($fp === false) {
             throw new TelegramException('Cannot open "' . $file . '" for reading');
         }
@@ -903,33 +904,6 @@ class Request
     public static function getUpdates(array $data)
     {
         return self::send('getUpdates', $data);
-    }
-
-    /**
-     * Set webhook
-     *
-     * @link https://core.telegram.org/bots/api#setwebhook
-     *
-     * @param string $url
-     * @param array  $data Optional parameters.
-     *
-     * @return \Longman\TelegramBot\Entities\ServerResponse
-     * @throws \Longman\TelegramBot\Exception\TelegramException
-     */
-    public static function setWebhook($url = '', array $data = [])
-    {
-        $data        = array_intersect_key($data, array_flip([
-            'certificate',
-            'max_connections',
-            'allowed_updates',
-        ]));
-        $data['url'] = $url;
-
-        if (isset($data['certificate'])) {
-            self::assignEncodedFile($data, 'certificate', $data['certificate']);
-        }
-
-        return self::send('setWebhook', $data);
     }
 
     /**

--- a/src/Request.php
+++ b/src/Request.php
@@ -219,11 +219,11 @@ class Request
         }
 
         // Make sure we have a string to work with.
-        if (is_string($input)) {
-            self::$input = $input;
-        } else {
+        if (!is_string($input)) {
             throw new TelegramException('Input must be a string!');
         }
+
+        self::$input = $input;
 
         TelegramLog::update(self::$input);
 
@@ -281,7 +281,7 @@ class Request
     private static function setUpRequestParams(array $data)
     {
         $has_resource = false;
-        $multipart = [];
+        $multipart    = [];
 
         // Convert any nested arrays into JSON strings.
         array_walk($data, function (&$item) {
@@ -291,7 +291,7 @@ class Request
         //Reformat data array in multipart way if it contains a resource
         foreach ($data as $key => $item) {
             $has_resource |= (is_resource($item) || $item instanceof \GuzzleHttp\Psr7\Stream);
-            $multipart[] = ['name' => $key, 'contents' => $item];
+            $multipart[]  = ['name' => $key, 'contents' => $item];
         }
         if ($has_resource) {
             return ['multipart' => $multipart];
@@ -316,8 +316,8 @@ class Request
             $data['reply_markup'] = json_encode($data['reply_markup']);
         }
 
-        $result = null;
-        $request_params = self::setUpRequestParams($data);
+        $result                  = null;
+        $request_params          = self::setUpRequestParams($data);
         $request_params['debug'] = TelegramLog::getDebugLogTempStream();
 
         try {
@@ -325,7 +325,7 @@ class Request
                 '/bot' . self::$telegram->getApiKey() . '/' . $action,
                 $request_params
             );
-            $result = (string) $response->getBody();
+            $result   = (string) $response->getBody();
 
             //Logging getUpdates Update
             if ($action === 'getUpdates') {
@@ -404,6 +404,7 @@ class Request
      * Send command
      *
      * @todo Fake response doesn't need json encoding?
+     * @todo Write debug entry on failure
      *
      * @param string $action
      * @param array  $data
@@ -598,7 +599,7 @@ class Request
             }
 
             self::$limiter_interval = $options['interval'];
-            self::$limiter_enabled = $value;
+            self::$limiter_enabled  = $value;
         }
     }
 
@@ -636,7 +637,7 @@ class Request
                 'setChatDescription',
             ];
 
-            $chat_id = isset($data['chat_id']) ? $data['chat_id'] : null;
+            $chat_id           = isset($data['chat_id']) ? $data['chat_id'] : null;
             $inline_message_id = isset($data['inline_message_id']) ? $data['inline_message_id'] : null;
 
             if (($chat_id || $inline_message_id) && in_array($action, $limited_methods)) {
@@ -649,7 +650,7 @@ class Request
 
                     $requests = DB::getTelegramRequestCount($chat_id, $inline_message_id);
 
-                    $chat_per_second = ($requests['LIMIT_PER_SEC'] == 0); // No more than one message per second inside a particular chat
+                    $chat_per_second   = ($requests['LIMIT_PER_SEC'] == 0); // No more than one message per second inside a particular chat
                     $global_per_second = ($requests['LIMIT_PER_SEC_ALL'] < 30);    // No more than 30 messages per second to different chats
                     $groups_per_minute = (((is_numeric($chat_id) && $chat_id > 0) || !is_null($inline_message_id)) || ((!is_numeric($chat_id) || $chat_id < 0) && $requests['LIMIT_PER_MINUTE'] < 20));    // No more than 20 messages per minute in groups and channels
 

--- a/src/Telegram.php
+++ b/src/Telegram.php
@@ -787,7 +787,19 @@ class Telegram
             throw new TelegramException('Hook url is empty!');
         }
 
-        $result = Request::setWebhook($url, $data);
+        $data        = array_intersect_key($data, array_flip([
+            'certificate',
+            'max_connections',
+            'allowed_updates',
+        ]));
+        $data['url'] = $url;
+
+        // If the certificate is passed as a path, encode and add the file to the data array.
+        if (!empty($data['certificate']) && is_string($data['certificate'])) {
+            $data['certificate'] = Request::encodeFile($data['certificate']);
+        }
+
+        $result = Request::setWebhook($data);
 
         if (!$result->isOk()) {
             throw new TelegramException(


### PR DESCRIPTION
This PR adds all new features from the Bot API 3.1 update.
Refactor `Request` class, removing most custom method implementations.

Note: New fields for [`Chat`](https://core.telegram.org/bots/api#chat) entity have NOT been added to the database structure, as the data can be unreliable, due to only being returned when explicitly requesting it via `getChat`.