### PR TITLE
Fix for 0.47.0

### DIFF
--- a/src/Commands/Command.php
+++ b/src/Commands/Command.php
@@ -368,17 +368,20 @@ abstract class Command
      */
     protected function removeNonPrivateMessage()
     {
-        $message = $this->getMessage();
-        $chat    = $message->getChat();
+        $message = $this->getMessage() ?: $this->getEditedMessage();
 
-        if (!$chat->isPrivateChat()) {
-            // Delete the falsely called command message.
-            Request::deleteMessage([
-                'chat_id'    => $chat->getId(),
-                'message_id' => $message->getMessageId(),
-            ]);
+        if ($message) {
+            $chat = $message->getChat();
 
-            return true;
+            if (!$chat->isPrivateChat()) {
+                // Delete the falsely called command message.
+                Request::deleteMessage([
+                    'chat_id'    => $chat->getId(),
+                    'message_id' => $message->getMessageId(),
+                ]);
+
+                return true;
+            }
         }
 
         return false;


### PR DESCRIPTION
Make sure we only filter update types that directly call a command

Fixes
`Error: Call to a member function getChat() on null in /home/jacklul/domains/jacklul.com/cat/e621searchbot/vendor/longman/telegram-bot/src/Commands/Command.php:372`
error in 0.47.0 when command with `$private_only = true` is called by non-message update type.