### PR TITLE
Correct the printError method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Exclamation symbols (:exclamation:) note something of importance e.g. breaking c
 ## [Unreleased]
 ### Added
 ### Changed
+- [:exclamation:][unreleased-correct-printerror] Corrected `ServerResponse->printError` method to print by default and return by setting `$return` parameter.
 ### Deprecated
 ### Removed
 ### Fixed
@@ -144,6 +145,7 @@ Exclamation symbols (:exclamation:) note something of importance e.g. breaking c
 ### Deprecated
 - Move `hideKeyboard` to `removeKeyboard`.
 
+[unreleased-correct-printerror]: https://github.com/php-telegram-bot/core/wiki/Breaking-backwards-compatibility#correct-printerror
 [0.47.0-private-only-admin-commands]: https://github.com/php-telegram-bot/core/wiki/Breaking-backwards-compatibility#private-only-admin-commands
 [0.46.0-bc-request-class-refactor]: https://github.com/php-telegram-bot/core/wiki/Breaking-backwards-compatibility#request-class-refactor
 [0.46.0-sql-migration]: https://github.com/php-telegram-bot/core/tree/0.45.0/utils/db-schema-update/0.44.1-0.45.0.sql

--- a/src/Entities/ServerResponse.php
+++ b/src/Entities/ServerResponse.php
@@ -77,11 +77,23 @@ class ServerResponse extends Entity
     /**
      * Print error
      *
-     * @return string
+     * @see https://secure.php.net/manual/en/function.print-r.php
+     *
+     * @param bool $return
+     *
+     * @return bool|string
      */
-    public function printError()
+    public function printError($return = false)
     {
-        return 'Error N: ' . $this->getErrorCode() . ' Description: ' . $this->getDescription();
+        $error = sprintf('Error N: %s, Description: %s', $this->getErrorCode(), $this->getDescription());
+
+        if ($return) {
+            return $error;
+        }
+
+        echo $error;
+
+        return true;
     }
 
     /**


### PR DESCRIPTION
Make it work like [`print_r`](https://secure.php.net/manual/en/function.print-r.php) regarding return value.

```php
$response->printError();              // prints error, returns true
$error = $response->printError(true); // returns error
```

Fixes #502 