### PR TITLE
Fix for #596

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Exclamation symbols (:exclamation:) note something of importance e.g. breaking c
 ### Deprecated
 ### Removed
 ### Fixed
+- Correctly save `reply_to_message` to DB.
 ### Security
 
 ## [0.47.1] - 2017-08-06

--- a/src/Entities/Message.php
+++ b/src/Entities/Message.php
@@ -57,7 +57,7 @@ class Message extends Entity
             'chat'              => Chat::class,
             'forward_from'      => User::class,
             'forward_from_chat' => Chat::class,
-            'reply_to_message'  => self::class,
+            'reply_to_message'  => ReplyToMessage::class,
             'entities'          => MessageEntity::class,
             'audio'             => Audio::class,
             'document'          => Document::class,


### PR DESCRIPTION
`reply_to_chat` and `reply_to_message` fields are not inserted because of this small mistake.