### PR TITLE
Implement some helper methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Exclamation symbols (:exclamation:) note something of importance e.g. breaking c
 ### Added
 - Donation section and links in readme.
 - Missing payment methods in `Request` class.
+- Some helper methods for replying to commands and answering queries.
 ### Changed
 - Updated and optimised all DB classes, removing a lot of bulky code.
 ### Deprecated

--- a/src/Commands/Command.php
+++ b/src/Commands/Command.php
@@ -386,4 +386,44 @@ abstract class Command
 
         return false;
     }
+
+    /**
+     * Helper to reply to a chat directly.
+     *
+     * @param string $text
+     * @param array  $data
+     *
+     * @return \Longman\TelegramBot\Entities\ServerResponse
+     */
+    public function replyToChat($text, array $data = [])
+    {
+        if ($message = $this->getMessage() ?: $this->getEditedMessage() ?: $this->getChannelPost() ?: $this->getEditedChannelPost()) {
+            return Request::sendMessage(array_merge([
+                'chat_id' => $message->getChat()->getId(),
+                'text'    => $text,
+            ], $data));
+        }
+
+        return Request::emptyResponse();
+    }
+
+    /**
+     * Helper to reply to a user directly.
+     *
+     * @param string $text
+     * @param array  $data
+     *
+     * @return \Longman\TelegramBot\Entities\ServerResponse
+     */
+    public function replyToUser($text, array $data = [])
+    {
+        if ($message = $this->getMessage() ?: $this->getEditedMessage()) {
+            return Request::sendMessage(array_merge([
+                'chat_id' => $message->getFrom()->getId(),
+                'text'    => $text,
+            ], $data));
+        }
+
+        return Request::emptyResponse();
+    }
 }

--- a/src/Entities/CallbackQuery.php
+++ b/src/Entities/CallbackQuery.php
@@ -10,6 +10,8 @@
 
 namespace Longman\TelegramBot\Entities;
 
+use Longman\TelegramBot\Request;
+
 /**
  * Class CallbackQuery.
  *
@@ -32,5 +34,19 @@ class CallbackQuery extends Entity
             'from'    => User::class,
             'message' => Message::class,
         ];
+    }
+
+    /**
+     * Answer this callback query.
+     *
+     * @param array $data
+     *
+     * @return ServerResponse
+     */
+    public function answer(array $data = [])
+    {
+        return Request::answerCallbackQuery(array_merge([
+            'callback_query_id' => $this->getId(),
+        ], $data));
     }
 }

--- a/src/Entities/InlineQuery.php
+++ b/src/Entities/InlineQuery.php
@@ -10,6 +10,8 @@
 
 namespace Longman\TelegramBot\Entities;
 
+use Longman\TelegramBot\Entities\InlineQuery\InlineQueryResult;
+
 /**
  * Class InlineQuery
  *
@@ -32,5 +34,21 @@ class InlineQuery extends Entity
             'from'     => User::class,
             'location' => Location::class,
         ];
+    }
+
+    /**
+     * Answer this inline query with the passed results.
+     *
+     * @param InlineQueryResult[] $results
+     * @param array               $data
+     *
+     * @return ServerResponse
+     */
+    public function answer(array $results, array $data = [])
+    {
+        return Request::answerCallbackQuery(array_merge([
+            'callback_query_id' => $this->getId(),
+            'results'           => $results,
+        ], $data));
     }
 }

--- a/src/Entities/InlineQuery/InlineQueryResult.php
+++ b/src/Entities/InlineQuery/InlineQueryResult.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Longman\TelegramBot\Entities\InlineQuery;
+
+interface InlineQueryResult
+{
+
+}

--- a/src/Entities/InlineQuery/InlineQueryResultArticle.php
+++ b/src/Entities/InlineQuery/InlineQueryResultArticle.php
@@ -56,7 +56,7 @@ use Longman\TelegramBot\Entities\InputMessageContent\InputMessageContent;
  * @method $this setThumbWidth(int $thumb_width)                                    Optional. Thumbnail width
  * @method $this setThumbHeight(int $thumb_height)                                  Optional. Thumbnail height
  */
-class InlineQueryResultArticle extends InlineEntity
+class InlineQueryResultArticle extends InlineEntity implements InlineQueryResult
 {
     /**
      * InlineQueryResultArticle constructor

--- a/src/Entities/InlineQuery/InlineQueryResultAudio.php
+++ b/src/Entities/InlineQuery/InlineQueryResultAudio.php
@@ -50,7 +50,7 @@ use Longman\TelegramBot\Entities\InputMessageContent\InputMessageContent;
  * @method $this setReplyMarkup(InlineKeyboard $reply_markup)                       Optional. Inline keyboard attached to the message
  * @method $this setInputMessageContent(InputMessageContent $input_message_content) Optional. Content of the message to be sent instead of the audio
  */
-class InlineQueryResultAudio extends InlineEntity
+class InlineQueryResultAudio extends InlineEntity implements InlineQueryResult
 {
     /**
      * InlineQueryResultAudio constructor

--- a/src/Entities/InlineQuery/InlineQueryResultCachedAudio.php
+++ b/src/Entities/InlineQuery/InlineQueryResultCachedAudio.php
@@ -41,7 +41,7 @@ use Longman\TelegramBot\Entities\InputMessageContent\InputMessageContent;
  * @method $this setReplyMarkup(InlineKeyboard $reply_markup)                       Optional. An Inline keyboard attached to the message
  * @method $this setInputMessageContent(InputMessageContent $input_message_content) Optional. Content of the message to be sent instead of the audio
  */
-class InlineQueryResultCachedAudio extends InlineEntity
+class InlineQueryResultCachedAudio extends InlineEntity implements InlineQueryResult
 {
     /**
      * InlineQueryResultCachedAudio constructor

--- a/src/Entities/InlineQuery/InlineQueryResultCachedDocument.php
+++ b/src/Entities/InlineQuery/InlineQueryResultCachedDocument.php
@@ -47,7 +47,7 @@ use Longman\TelegramBot\Entities\InputMessageContent\InputMessageContent;
  * @method $this setReplyMarkup(InlineKeyboard $reply_markup)                       Optional. An Inline keyboard attached to the message
  * @method $this setInputMessageContent(InputMessageContent $input_message_content) Optional. Content of the message to be sent instead of the file
  */
-class InlineQueryResultCachedDocument extends InlineEntity
+class InlineQueryResultCachedDocument extends InlineEntity implements InlineQueryResult
 {
     /**
      * InlineQueryResultCachedDocument constructor

--- a/src/Entities/InlineQuery/InlineQueryResultCachedGif.php
+++ b/src/Entities/InlineQuery/InlineQueryResultCachedGif.php
@@ -44,7 +44,7 @@ use Longman\TelegramBot\Entities\InputMessageContent\InputMessageContent;
  * @method $this setReplyMarkup(InlineKeyboard $reply_markup)                       Optional. An Inline keyboard attached to the message
  * @method $this setInputMessageContent(InputMessageContent $input_message_content) Optional. Content of the message to be sent instead of the GIF animation
  */
-class InlineQueryResultCachedGif extends InlineEntity
+class InlineQueryResultCachedGif extends InlineEntity implements InlineQueryResult
 {
     /**
      * InlineQueryResultCachedGif constructor

--- a/src/Entities/InlineQuery/InlineQueryResultCachedMpeg4Gif.php
+++ b/src/Entities/InlineQuery/InlineQueryResultCachedMpeg4Gif.php
@@ -44,7 +44,7 @@ use Longman\TelegramBot\Entities\InputMessageContent\InputMessageContent;
  * @method $this setReplyMarkup(InlineKeyboard $reply_markup)                       Optional. An Inline keyboard attached to the message
  * @method $this setInputMessageContent(InputMessageContent $input_message_content) Optional. Content of the message to be sent instead of the video animation
  */
-class InlineQueryResultCachedMpeg4Gif extends InlineEntity
+class InlineQueryResultCachedMpeg4Gif extends InlineEntity implements InlineQueryResult
 {
     /**
      * InlineQueryResultCachedMpeg4Gif constructor

--- a/src/Entities/InlineQuery/InlineQueryResultCachedPhoto.php
+++ b/src/Entities/InlineQuery/InlineQueryResultCachedPhoto.php
@@ -47,7 +47,7 @@ use Longman\TelegramBot\Entities\InputMessageContent\InputMessageContent;
  * @method $this setReplyMarkup(InlineKeyboard $reply_markup)                       Optional. Inline keyboard attached to the message
  * @method $this setInputMessageContent(InputMessageContent $input_message_content) Optional. Content of the message to be sent instead of the photo
  */
-class InlineQueryResultCachedPhoto extends InlineEntity
+class InlineQueryResultCachedPhoto extends InlineEntity implements InlineQueryResult
 {
     /**
      * InlineQueryResultCachedPhoto constructor

--- a/src/Entities/InlineQuery/InlineQueryResultCachedSticker.php
+++ b/src/Entities/InlineQuery/InlineQueryResultCachedSticker.php
@@ -38,7 +38,7 @@ use Longman\TelegramBot\Entities\InputMessageContent\InputMessageContent;
  * @method $this setReplyMarkup(InlineKeyboard $reply_markup)                       Optional. An Inline keyboard attached to the message
  * @method $this setInputMessageContent(InputMessageContent $input_message_content) Optional. Content of the message to be sent instead of the sticker
  */
-class InlineQueryResultCachedSticker extends InlineEntity
+class InlineQueryResultCachedSticker extends InlineEntity implements InlineQueryResult
 {
     /**
      * InlineQueryResultCachedSticker constructor

--- a/src/Entities/InlineQuery/InlineQueryResultCachedVideo.php
+++ b/src/Entities/InlineQuery/InlineQueryResultCachedVideo.php
@@ -47,7 +47,7 @@ use Longman\TelegramBot\Entities\InputMessageContent\InputMessageContent;
  * @method $this setReplyMarkup(InlineKeyboard $reply_markup)                       Optional. An Inline keyboard attached to the message
  * @method $this setInputMessageContent(InputMessageContent $input_message_content) Optional. Content of the message to be sent instead of the video
  */
-class InlineQueryResultCachedVideo extends InlineEntity
+class InlineQueryResultCachedVideo extends InlineEntity implements InlineQueryResult
 {
     /**
      * InlineQueryResultCachedVideo constructor

--- a/src/Entities/InlineQuery/InlineQueryResultCachedVoice.php
+++ b/src/Entities/InlineQuery/InlineQueryResultCachedVoice.php
@@ -44,7 +44,7 @@ use Longman\TelegramBot\Entities\InputMessageContent\InputMessageContent;
  * @method $this setReplyMarkup(InlineKeyboard $reply_markup)                       Optional. An Inline keyboard attached to the message
  * @method $this setInputMessageContent(InputMessageContent $input_message_content) Optional. Content of the message to be sent instead of the voice message
  */
-class InlineQueryResultCachedVoice extends InlineEntity
+class InlineQueryResultCachedVoice extends InlineEntity implements InlineQueryResult
 {
     /**
      * InlineQueryResultCachedVoice constructor

--- a/src/Entities/InlineQuery/InlineQueryResultContact.php
+++ b/src/Entities/InlineQuery/InlineQueryResultContact.php
@@ -53,7 +53,7 @@ use Longman\TelegramBot\Entities\InputMessageContent\InputMessageContent;
  * @method $this setThumbWidth(int $thumb_width)                                    Optional. Thumbnail width
  * @method $this setThumbHeight(int $thumb_height)                                  Optional. Thumbnail height
  */
-class InlineQueryResultContact extends InlineEntity
+class InlineQueryResultContact extends InlineEntity implements InlineQueryResult
 {
     /**
      * InlineQueryResultContact constructor

--- a/src/Entities/InlineQuery/InlineQueryResultDocument.php
+++ b/src/Entities/InlineQuery/InlineQueryResultDocument.php
@@ -59,7 +59,7 @@ use Longman\TelegramBot\Entities\InputMessageContent\InputMessageContent;
  * @method $this setThumbWidth(int $thumb_width)                                    Optional. Thumbnail width
  * @method $this setThumbHeight(int $thumb_height)                                  Optional. Thumbnail height
  */
-class InlineQueryResultDocument extends InlineEntity
+class InlineQueryResultDocument extends InlineEntity implements InlineQueryResult
 {
     /**
      * InlineQueryResultDocument constructor

--- a/src/Entities/InlineQuery/InlineQueryResultGif.php
+++ b/src/Entities/InlineQuery/InlineQueryResultGif.php
@@ -55,7 +55,7 @@ use Longman\TelegramBot\Entities\InputMessageContent\InputMessageContent;
  * @method $this setReplyMarkup(InlineKeyboard $reply_markup)                       Optional. Inline keyboard attached to the message
  * @method $this setInputMessageContent(InputMessageContent $input_message_content) Optional. Content of the message to be sent instead of the GIF animation
  */
-class InlineQueryResultGif extends InlineEntity
+class InlineQueryResultGif extends InlineEntity implements InlineQueryResult
 {
     /**
      * InlineQueryResultGif constructor

--- a/src/Entities/InlineQuery/InlineQueryResultLocation.php
+++ b/src/Entities/InlineQuery/InlineQueryResultLocation.php
@@ -53,7 +53,7 @@ use Longman\TelegramBot\Entities\InputMessageContent\InputMessageContent;
  * @method $this setThumbWidth(int $thumb_width)                                    Optional. Thumbnail width
  * @method $this setThumbHeight(int $thumb_height)                                  Optional. Thumbnail height
  */
-class InlineQueryResultLocation extends InlineEntity
+class InlineQueryResultLocation extends InlineEntity implements InlineQueryResult
 {
     /**
      * InlineQueryResultLocation constructor

--- a/src/Entities/InlineQuery/InlineQueryResultMpeg4Gif.php
+++ b/src/Entities/InlineQuery/InlineQueryResultMpeg4Gif.php
@@ -55,7 +55,7 @@ use Longman\TelegramBot\Entities\InputMessageContent\InputMessageContent;
  * @method $this setReplyMarkup(InlineKeyboard $reply_markup)                       Optional. Inline keyboard attached to the message
  * @method $this setInputMessageContent(InputMessageContent $input_message_content) Optional. Content of the message to be sent instead of the video animation
  */
-class InlineQueryResultMpeg4Gif extends InlineEntity
+class InlineQueryResultMpeg4Gif extends InlineEntity implements InlineQueryResult
 {
     /**
      * InlineQueryResultMpeg4Gif constructor

--- a/src/Entities/InlineQuery/InlineQueryResultPhoto.php
+++ b/src/Entities/InlineQuery/InlineQueryResultPhoto.php
@@ -56,7 +56,7 @@ use Longman\TelegramBot\Entities\InputMessageContent\InputMessageContent;
  * @method $this setReplyMarkup(InlineKeyboard $reply_markup)                       Optional. Inline keyboard attached to the message
  * @method $this setInputMessageContent(InputMessageContent $input_message_content) Optional. Content of the message to be sent instead of the photo
  */
-class InlineQueryResultPhoto extends InlineEntity
+class InlineQueryResultPhoto extends InlineEntity implements InlineQueryResult
 {
     /**
      * InlineQueryResultPhoto constructor

--- a/src/Entities/InlineQuery/InlineQueryResultVenue.php
+++ b/src/Entities/InlineQuery/InlineQueryResultVenue.php
@@ -59,7 +59,7 @@ use Longman\TelegramBot\Entities\InputMessageContent\InputMessageContent;
  * @method $this setThumbWidth(int $thumb_width)                                    Optional. Thumbnail width
  * @method $this setThumbHeight(int $thumb_height)                                  Optional. Thumbnail height
  */
-class InlineQueryResultVenue extends InlineEntity
+class InlineQueryResultVenue extends InlineEntity implements InlineQueryResult
 {
     /**
      * InlineQueryResultVenue constructor

--- a/src/Entities/InlineQuery/InlineQueryResultVideo.php
+++ b/src/Entities/InlineQuery/InlineQueryResultVideo.php
@@ -62,7 +62,7 @@ use Longman\TelegramBot\Entities\InputMessageContent\InputMessageContent;
  * @method $this setReplyMarkup(InlineKeyboard $reply_markup)                       Optional. Inline keyboard attached to the message
  * @method $this setInputMessageContent(InputMessageContent $input_message_content) Optional. Content of the message to be sent instead of the video
  */
-class InlineQueryResultVideo extends InlineEntity
+class InlineQueryResultVideo extends InlineEntity implements InlineQueryResult
 {
     /**
      * InlineQueryResultVideo constructor

--- a/src/Entities/InlineQuery/InlineQueryResultVoice.php
+++ b/src/Entities/InlineQuery/InlineQueryResultVoice.php
@@ -47,7 +47,7 @@ use Longman\TelegramBot\Entities\InputMessageContent\InputMessageContent;
  * @method $this setReplyMarkup(InlineKeyboard $reply_markup)                       Optional. Inline keyboard attached to the message
  * @method $this setInputMessageContent(InputMessageContent $input_message_content) Optional. Content of the message to be sent instead of the voice recording
  */
-class InlineQueryResultVoice extends InlineEntity
+class InlineQueryResultVoice extends InlineEntity implements InlineQueryResult
 {
     /**
      * InlineQueryResultVoice constructor

--- a/src/Entities/Payments/PreCheckoutQuery.php
+++ b/src/Entities/Payments/PreCheckoutQuery.php
@@ -12,6 +12,7 @@ namespace Longman\TelegramBot\Entities\Payments;
 
 use Longman\TelegramBot\Entities\Entity;
 use Longman\TelegramBot\Entities\User;
+use Longman\TelegramBot\Request;
 
 /**
  * Class PreCheckoutQuery
@@ -39,5 +40,21 @@ class PreCheckoutQuery extends Entity
             'user'       => User::class,
             'order_info' => OrderInfo::class,
         ];
+    }
+
+    /**
+     * Answer this pre-checkout query.
+     *
+     * @param bool  $ok
+     * @param array $data
+     *
+     * @return \Longman\TelegramBot\Entities\ServerResponse
+     */
+    public function answer($ok, array $data = [])
+    {
+        return Request::answerPreCheckoutQuery(array_merge([
+            'pre_checkout_query_id' => $this->getId(),
+            'ok'                    => $ok,
+        ], $data));
     }
 }

--- a/src/Entities/Payments/ShippingQuery.php
+++ b/src/Entities/Payments/ShippingQuery.php
@@ -12,6 +12,7 @@ namespace Longman\TelegramBot\Entities\Payments;
 
 use Longman\TelegramBot\Entities\Entity;
 use Longman\TelegramBot\Entities\User;
+use Longman\TelegramBot\Request;
 
 /**
  * Class ShippingQuery
@@ -36,5 +37,21 @@ class ShippingQuery extends Entity
             'user'             => User::class,
             'shipping_address' => ShippingAddress::class,
         ];
+    }
+
+    /**
+     * Answer this shipping query.
+     *
+     * @param bool  $ok
+     * @param array $data
+     *
+     * @return \Longman\TelegramBot\Entities\ServerResponse
+     */
+    public function answer($ok, array $data = [])
+    {
+        return Request::answerShippingQuery(array_merge([
+            'shipping_query_id' => $this->getId(),
+            'ok'                => $ok,
+        ], $data));
     }
 }


### PR DESCRIPTION
...for replying to commands and answering queries.

(*Note:* Relies on #633 that add query answering for Payments.)

This a part of #576 (maybe more will come later).

For now though, simply add helpers to reply to messages and answer the various queries (Callback, Inline, Payments) more directly from inside commands.

```php
$this->replyToChat('My reply text', $data_array_for_any_extras);
```
vs.
```php
$data = [
    'chat_id' => $this->getMessage()->getChat()->getId(),
    'text'   => 'My reply text',
    // any extras, like keyboard, parse mode, etc.
];
Request::sendMessage($data);
```

(This takes `Message`, `EditedMessage`, `ChannelPost` and `EditedChannelPost` into account.)

To answer a query callback:
```php
$callback_query->answer(['text' => 'Settings updated!']);
```
vs.
```php
$data = [
    'callback_query_id' => $this->getCallbackQuery()->getId(),
    'text'              => 'Settings updated!',
    // any extras, like notification text, keyboard, parse mode, etc.
];
Request::answerCallbackQuery($data);
```