### PR TITLE
Add missing Payment properties to Message entity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Exclamation symbols (:exclamation:) note something of importance e.g. breaking c
 
 ## [Unreleased]
 ### Added
+- Finish implementing payments, adding all missing type checks and docblock methods.
 ### Changed
 ### Deprecated
 ### Removed

--- a/src/Entities/Message.php
+++ b/src/Entities/Message.php
@@ -10,42 +10,47 @@
 
 namespace Longman\TelegramBot\Entities;
 
+use Longman\TelegramBot\Entities\Payments\Invoice;
+use Longman\TelegramBot\Entities\Payments\SuccessfulPayment;
+
 /**
  * Class Message
  *
  * @link https://core.telegram.org/bots/api#message
  *
- * @method int          getMessageId()             Unique message identifier
- * @method User         getFrom()                  Optional. Sender, can be empty for messages sent to channels
- * @method int          getDate()                  Date the message was sent in Unix time
- * @method Chat         getChat()                  Conversation the message belongs to
- * @method User         getForwardFrom()           Optional. For forwarded messages, sender of the original message
- * @method Chat         getForwardFromChat()       Optional. For messages forwarded from a channel, information about the original channel
- * @method int          getForwardFromMessageId()  Optional. For forwarded channel posts, identifier of the original message in the channel
- * @method string       getForwardSignature()      Optional. For messages forwarded from channels, signature of the post author if present
- * @method int          getForwardDate()           Optional. For forwarded messages, date the original message was sent in Unix time
- * @method Message      getReplyToMessage()        Optional. For replies, the original message. Note that the Message object in this field will not contain further reply_to_message fields even if it itself is a reply.
- * @method int          getEditDate()              Optional. Date the message was last edited in Unix time
- * @method string       getAuthorSignature()       Optional. Signature of the post author for messages in channels
- * @method Audio        getAudio()                 Optional. Message is an audio file, information about the file
- * @method Document     getDocument()              Optional. Message is a general file, information about the file
- * @method Sticker      getSticker()               Optional. Message is a sticker, information about the sticker
- * @method Video        getVideo()                 Optional. Message is a video, information about the video
- * @method Voice        getVoice()                 Optional. Message is a voice message, information about the file
- * @method VideoNote    getVideoNote()             Optional. Message is a video note message, information about the video
- * @method string       getCaption()               Optional. Caption for the document, photo or video, 0-200 characters
- * @method Contact      getContact()               Optional. Message is a shared contact, information about the contact
- * @method Location     getLocation()              Optional. Message is a shared location, information about the location
- * @method Venue        getVenue()                 Optional. Message is a venue, information about the venue
- * @method User         getLeftChatMember()        Optional. A member was removed from the group, information about them (this member may be the bot itself)
- * @method string       getNewChatTitle()          Optional. A chat title was changed to this value
- * @method bool         getDeleteChatPhoto()       Optional. Service message: the chat photo was deleted
- * @method bool         getGroupChatCreated()      Optional. Service message: the group has been created
- * @method bool         getSupergroupChatCreated() Optional. Service message: the supergroup has been created. This field can't be received in a message coming through updates, because bot can’t be a member of a supergroup when it is created. It can only be found in reply_to_message if someone replies to a very first message in a directly created supergroup.
- * @method bool         getChannelChatCreated()    Optional. Service message: the channel has been created. This field can't be received in a message coming through updates, because bot can’t be a member of a channel when it is created. It can only be found in reply_to_message if someone replies to a very first message in a channel.
- * @method int          getMigrateToChatId()       Optional. The group has been migrated to a supergroup with the specified identifier. This number may be greater than 32 bits and some programming languages may have difficulty/silent defects in interpreting it. But it smaller than 52 bits, so a signed 64 bit integer or double-precision float type are safe for storing this identifier.
- * @method int          getMigrateFromChatId()     Optional. The supergroup has been migrated from a group with the specified identifier. This number may be greater than 32 bits and some programming languages may have difficulty/silent defects in interpreting it. But it smaller than 52 bits, so a signed 64 bit integer or double-precision float type are safe for storing this identifier.
- * @method Message      getPinnedMessage()         Optional. Specified message was pinned. Note that the Message object in this field will not contain further reply_to_message fields even if it is itself a reply.
+ * @method int               getMessageId()             Unique message identifier
+ * @method User              getFrom()                  Optional. Sender, can be empty for messages sent to channels
+ * @method int               getDate()                  Date the message was sent in Unix time
+ * @method Chat              getChat()                  Conversation the message belongs to
+ * @method User              getForwardFrom()           Optional. For forwarded messages, sender of the original message
+ * @method Chat              getForwardFromChat()       Optional. For messages forwarded from a channel, information about the original channel
+ * @method int               getForwardFromMessageId()  Optional. For forwarded channel posts, identifier of the original message in the channel
+ * @method string            getForwardSignature()      Optional. For messages forwarded from channels, signature of the post author if present
+ * @method int               getForwardDate()           Optional. For forwarded messages, date the original message was sent in Unix time
+ * @method Message           getReplyToMessage()        Optional. For replies, the original message. Note that the Message object in this field will not contain further reply_to_message fields even if it itself is a reply.
+ * @method int               getEditDate()              Optional. Date the message was last edited in Unix time
+ * @method string            getAuthorSignature()       Optional. Signature of the post author for messages in channels
+ * @method Audio             getAudio()                 Optional. Message is an audio file, information about the file
+ * @method Document          getDocument()              Optional. Message is a general file, information about the file
+ * @method Sticker           getSticker()               Optional. Message is a sticker, information about the sticker
+ * @method Video             getVideo()                 Optional. Message is a video, information about the video
+ * @method Voice             getVoice()                 Optional. Message is a voice message, information about the file
+ * @method VideoNote         getVideoNote()             Optional. Message is a video note message, information about the video
+ * @method string            getCaption()               Optional. Caption for the document, photo or video, 0-200 characters
+ * @method Contact           getContact()               Optional. Message is a shared contact, information about the contact
+ * @method Location          getLocation()              Optional. Message is a shared location, information about the location
+ * @method Venue             getVenue()                 Optional. Message is a venue, information about the venue
+ * @method User              getLeftChatMember()        Optional. A member was removed from the group, information about them (this member may be the bot itself)
+ * @method string            getNewChatTitle()          Optional. A chat title was changed to this value
+ * @method bool              getDeleteChatPhoto()       Optional. Service message: the chat photo was deleted
+ * @method bool              getGroupChatCreated()      Optional. Service message: the group has been created
+ * @method bool              getSupergroupChatCreated() Optional. Service message: the supergroup has been created. This field can't be received in a message coming through updates, because bot can’t be a member of a supergroup when it is created. It can only be found in reply_to_message if someone replies to a very first message in a directly created supergroup.
+ * @method bool              getChannelChatCreated()    Optional. Service message: the channel has been created. This field can't be received in a message coming through updates, because bot can’t be a member of a channel when it is created. It can only be found in reply_to_message if someone replies to a very first message in a channel.
+ * @method int               getMigrateToChatId()       Optional. The group has been migrated to a supergroup with the specified identifier. This number may be greater than 32 bits and some programming languages may have difficulty/silent defects in interpreting it. But it smaller than 52 bits, so a signed 64 bit integer or double-precision float type are safe for storing this identifier.
+ * @method int               getMigrateFromChatId()     Optional. The supergroup has been migrated from a group with the specified identifier. This number may be greater than 32 bits and some programming languages may have difficulty/silent defects in interpreting it. But it smaller than 52 bits, so a signed 64 bit integer or double-precision float type are safe for storing this identifier.
+ * @method Message           getPinnedMessage()         Optional. Specified message was pinned. Note that the Message object in this field will not contain further reply_to_message fields even if it is itself a reply.
+ * @method Invoice           getInvoice()               Optional. Message is an invoice for a payment, information about the invoice.
+ * @method SuccessfulPayment getSuccessfulPayment()     Optional. Message is a service message about a successful payment, information about the payment.
  */
 class Message extends Entity
 {
@@ -55,26 +60,28 @@ class Message extends Entity
     protected function subEntities()
     {
         return [
-            'from'              => User::class,
-            'chat'              => Chat::class,
-            'forward_from'      => User::class,
-            'forward_from_chat' => Chat::class,
-            'reply_to_message'  => ReplyToMessage::class,
-            'entities'          => MessageEntity::class,
-            'audio'             => Audio::class,
-            'document'          => Document::class,
-            'photo'             => PhotoSize::class,
-            'sticker'           => Sticker::class,
-            'video'             => Video::class,
-            'voice'             => Voice::class,
-            'video_note'        => VideoNote::class,
-            'contact'           => Contact::class,
-            'location'          => Location::class,
-            'venue'             => Venue::class,
-            'new_chat_members'  => User::class,
-            'left_chat_member'  => User::class,
-            'new_chat_photo'    => PhotoSize::class,
-            'pinned_message'    => Message::class,
+            'from'               => User::class,
+            'chat'               => Chat::class,
+            'forward_from'       => User::class,
+            'forward_from_chat'  => Chat::class,
+            'reply_to_message'   => ReplyToMessage::class,
+            'entities'           => MessageEntity::class,
+            'audio'              => Audio::class,
+            'document'           => Document::class,
+            'photo'              => PhotoSize::class,
+            'sticker'            => Sticker::class,
+            'video'              => Video::class,
+            'voice'              => Voice::class,
+            'video_note'         => VideoNote::class,
+            'contact'            => Contact::class,
+            'location'           => Location::class,
+            'venue'              => Venue::class,
+            'new_chat_members'   => User::class,
+            'left_chat_member'   => User::class,
+            'new_chat_photo'     => PhotoSize::class,
+            'pinned_message'     => Message::class,
+            'invoice'            => Invoice::class,
+            'successful_payment' => SuccessfulPayment::class,
         ];
     }
 
@@ -244,7 +251,7 @@ class Message extends Entity
     /**
      * Detect type based on properties.
      *
-     * @return string|null
+     * @return string
      */
     public function getType()
     {
@@ -270,6 +277,8 @@ class Message extends Entity
             'migrate_to_chat_id',
             'migrate_from_chat_id',
             'pinned_message',
+            'invoice',
+            'successful_payment',
         ];
 
         foreach ($types as $type) {

--- a/src/Telegram.php
+++ b/src/Telegram.php
@@ -420,9 +420,7 @@ class Telegram
         $command = 'genericmessage';
 
         $update_type = $this->update->getUpdateType();
-        if (in_array($update_type, ['edited_message', 'channel_post', 'edited_channel_post', 'inline_query', 'chosen_inline_result', 'callback_query'], true)) {
-            $command = $this->getCommandFromType($update_type);
-        } elseif ($update_type === 'message') {
+        if ($update_type === 'message') {
             $message = $this->update->getMessage();
 
             //Load admin commands
@@ -434,21 +432,25 @@ class Telegram
             if ($type === 'command') {
                 $command = $message->getCommand();
             } elseif (in_array($type, [
-                'channel_chat_created',
+                'new_chat_members',
+                'left_chat_member',
+                'new_chat_title',
+                'new_chat_photo',
                 'delete_chat_photo',
                 'group_chat_created',
-                'left_chat_member',
-                'migrate_from_chat_id',
-                'migrate_to_chat_id',
-                'new_chat_members',
-                'new_chat_photo',
-                'new_chat_title',
-                'pinned_message',
                 'supergroup_chat_created',
+                'channel_chat_created',
+                'migrate_to_chat_id',
+                'migrate_from_chat_id',
+                'pinned_message',
+                'invoice',
+                'successful_payment',
             ], true)
             ) {
                 $command = $this->getCommandFromType($type);
             }
+        } else {
+            $command = $this->getCommandFromType($update_type);
         }
 
         //Make sure we have an up-to-date command list


### PR DESCRIPTION
Also add missing type checks, removing some unnecessary ones.

@jacklul Just to be safe, `Telegram.php:423` really isn't required, right? It's literally an array of all other types except for `message`, which is checked in the other `if`. There can't be any other value there anyway, right?