### PR TITLE
Scrutinizer improvements

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -19,4 +19,4 @@ checks:
 
 tools:
     external_code_coverage:
-        timeout: 600
+        timeout: 120

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,12 @@ Exclamation symbols (:exclamation:) note something of importance e.g. breaking c
 ### Added
 - Finish implementing payments, adding all missing type checks and docblock methods.
 ### Changed
+- [:exclamation:][unreleased-bc-messagegetcommand-return-value] `Message::getCommand()` returns `null` if not a command, instead of `false`.
 ### Deprecated
 ### Removed
 ### Fixed
 - SQL update script for version 0.44.1-0.45.0.
+- Issues found by Scrutinizer (Type hints and return values).
 ### Security
 
 ## [0.49.0] - 2017-09-17
@@ -169,6 +171,7 @@ Exclamation symbols (:exclamation:) note something of importance e.g. breaking c
 ### Deprecated
 - Move `hideKeyboard` to `removeKeyboard`.
 
+[unreleased-bc-messagegetcommand-return-value]: https://github.com/php-telegram-bot/core/wiki/Breaking-backwards-compatibility#messagegetcommand-return-value
 [0.48.0-sql-migration]: https://github.com/php-telegram-bot/core/tree/develop/utils/db-schema-update/0.47.1-0.48.0.sql
 [0.48.0-bc-correct-printerror]: https://github.com/php-telegram-bot/core/wiki/Breaking-backwards-compatibility#correct-printerror
 [0.47.0-bc-private-only-admin-commands]: https://github.com/php-telegram-bot/core/wiki/Breaking-backwards-compatibility#private-only-admin-commands

--- a/src/DB.php
+++ b/src/DB.php
@@ -452,7 +452,7 @@ class DB
             $chat_id   = $chat->getId();
             $chat_type = $chat->getType();
 
-            if ($migrate_to_chat_id) {
+            if ($migrate_to_chat_id !== null) {
                 $chat_type = 'supergroup';
 
                 $sth->bindValue(':id', $migrate_to_chat_id);
@@ -872,7 +872,7 @@ class DB
             $sth->bindValue(':forward_date', $forward_date);
 
             $reply_to_chat_id = null;
-            if ($reply_to_message_id) {
+            if ($reply_to_message_id !== null) {
                 $reply_to_chat_id = $chat_id;
             }
             $sth->bindValue(':reply_to_chat', $reply_to_chat_id);

--- a/src/Entities/Message.php
+++ b/src/Entities/Message.php
@@ -190,7 +190,7 @@ class Message extends Entity
 
         $full_command = $this->getFullCommand();
         if (strpos($full_command, '/') !== 0) {
-            return false;
+            return null;
         }
         $full_command = substr($full_command, 1);
 
@@ -281,9 +281,10 @@ class Message extends Entity
             'successful_payment',
         ];
 
+        $is_command = strlen($this->getCommand()) > 0;
         foreach ($types as $type) {
             if ($this->getProperty($type)) {
-                if ($type === 'text' && $this->getCommand()) {
+                if ($is_command && $type === 'text') {
                     return 'command';
                 }
 

--- a/tests/unit/Entities/MessageTest.php
+++ b/tests/unit/Entities/MessageTest.php
@@ -30,8 +30,8 @@ class MessageTest extends TestCase
 
         // text
         $message = TestHelpers::getFakeMessageObject(['text' => 'some text']);
-        self::assertEquals('', $message->getFullCommand());
-        self::assertEquals('', $message->getCommand());
+        self::assertNull($message->getFullCommand());
+        self::assertNull($message->getCommand());
         self::assertEquals('some text', $message->getText());
         self::assertEquals('some text', $message->getText(true));
 


### PR DESCRIPTION
Some improvements and fixes found by Scrutinizer, reducing the timeout for external code coverage to speed up manual triggers.

Fix return value of `Message::getCommand()` if message is text only. Now returns `null` instead of `false`.