### PR TITLE
Log api.telegram response errors

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -360,6 +360,7 @@ class Request
                 TelegramLog::update($result);
             }
         } catch (RequestException $e) {
+            TelegramLog::error($e);
             $result = ($e->getResponse()) ? (string) $e->getResponse()->getBody() : '';
         } finally {
             //Logging verbose debug output


### PR DESCRIPTION
Telegram has very strong size restriction for Reply Button callback_data. It is very helpful to see response error in error log. 

I do not create issue as this is very small improvement.  