### PR TITLE
Allow empty string for `switch_inline_query` parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Exclamation symbols (:exclamation:) note something of importance e.g. breaking c
 ### Removed
 ### Fixed
 - Entity relations and wrong types for payments.
+- Allow empty string for `switch_inline_query` and `switch_inline_query_current_chat` (InlineKeyboardButton).
 ### Security
 
 ## [0.51.0] - 2017-12-05

--- a/src/Entities/InlineKeyboardButton.php
+++ b/src/Entities/InlineKeyboardButton.php
@@ -63,8 +63,14 @@ class InlineKeyboardButton extends KeyboardButton
 
         $num_params = 0;
 
-        foreach (['url', 'callback_data', 'switch_inline_query', 'switch_inline_query_current_chat', 'pay'] as $param) {
+        foreach (['url', 'callback_data', 'pay'] as $param) {
             if ($this->getProperty($param, '') !== '') {
+                $num_params++;
+            }
+        }
+
+        foreach (['switch_inline_query', 'switch_inline_query_current_chat'] as $param) {
+            if ($this->getProperty($param) !== null) {
                 $num_params++;
             }
         }

--- a/src/Entities/InlineQuery.php
+++ b/src/Entities/InlineQuery.php
@@ -11,6 +11,7 @@
 namespace Longman\TelegramBot\Entities;
 
 use Longman\TelegramBot\Entities\InlineQuery\InlineQueryResult;
+use Longman\TelegramBot\Request;
 
 /**
  * Class InlineQuery

--- a/tests/unit/Entities/InlineKeyboardButtonTest.php
+++ b/tests/unit/Entities/InlineKeyboardButtonTest.php
@@ -91,7 +91,9 @@ class InlineKeyboardButtonTest extends TestCase
         new InlineKeyboardButton(['text' => 'message', 'url' => 'url_value']);
         new InlineKeyboardButton(['text' => 'message', 'callback_data' => 'callback_data_value']);
         new InlineKeyboardButton(['text' => 'message', 'switch_inline_query' => 'switch_inline_query_value']);
+        new InlineKeyboardButton(['text' => 'message', 'switch_inline_query' => '']); // Allow empty string.
         new InlineKeyboardButton(['text' => 'message', 'switch_inline_query_current_chat' => 'switch_inline_query_current_chat_value']);
+        new InlineKeyboardButton(['text' => 'message', 'switch_inline_query_current_chat' => '']); // Allow empty string.
         new InlineKeyboardButton(['text' => 'message', 'pay' => true]);
     }
 


### PR DESCRIPTION
Fixes #735 