### PR TITLE
Update scripts lines to work on both Unix and Windows

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,13 +41,13 @@
     },
     "scripts": {
         "check-code": [
-            "./vendor/bin/phpcs --standard=phpcs.xml -snp --encoding=utf-8 src/ tests/ --report-width=150"
+            "\"vendor/bin/phpcs\" --standard=phpcs.xml -snp --encoding=utf-8 src/ tests/ --report-width=150"
         ],
         "test": [
-            "./vendor/bin/phpunit"
+            "\"vendor/bin/phpunit\""
         ],
         "test-cov": [
-            "./vendor/bin/phpunit --coverage-clover build/logs/clover.xml"
+            "\"vendor/bin/phpunit\" --coverage-clover build/logs/clover.xml"
         ],
         "test-cov-upload": [
             "wget https://scrutinizer-ci.com/ocular.phar && php ocular.phar code-coverage:upload --format=php-clover build/logs/clover.xml"


### PR DESCRIPTION
This shouldn't break anything.
Tested it in Windows command line and linux subsystem.

Currently on windows command line it doesn't seem to execute:
```
>composer check-code
> ./vendor/bin/phpcs --standard=phpcs.xml -snp --encoding=utf-8 src/ tests/ --report-width=150
'.' is not recognized as an internal or external command,
operable program or batch file.
Script ./vendor/bin/phpcs --standard=phpcs.xml -snp --encoding=utf-8 src/ tests/ --report-width=150 handling the check-code event returned with error code 1
```