### PR TITLE
Fix method call for sending messages with /sendtochannel command.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Exclamation symbols (:exclamation:) note something of importance e.g. breaking c
 ### Removed
 ### Fixed
 - PHPCS fixes for updated CodeSniffer dependency.
+- Send messages correctly via `/sendtochannel`.
 ### Security
 
 ## [0.52.0] - 2018-01-07

--- a/src/Commands/AdminCommands/SendtochannelCommand.php
+++ b/src/Commands/AdminCommands/SendtochannelCommand.php
@@ -290,13 +290,7 @@ class SendtochannelCommand extends AdminCommand
             $data['longitude'] = $message->getLocation()->getLongitude();
         }
 
-        $callback_path     = 'Longman\TelegramBot\Request';
-        $callback_function = 'send' . ucfirst($type);
-        if (!method_exists($callback_path, $callback_function)) {
-            throw new TelegramException('Methods: ' . $callback_function . ' not found in class Request.');
-        }
-
-        return $callback_path::$callback_function($data);
+        return Request::send('send' . ucfirst($type), $data);
     }
 
     /**


### PR DESCRIPTION
Update the sending method of `/sendtochannel` to use the magic `Request::__callStatic` method.

Fixes #798 