### PR TITLE
Improve admin send commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Exclamation symbols (:exclamation:) note something of importance e.g. breaking c
 - Updated Travis to use Trusty containers (for HHVM) and add PHP 7.2 to the tests.
 - Add debug log entry instead of throwing an exception for duplicate updates.
 - `Telegram::handleGetUpdates()` can now work without a database connection (not enabled by default).
+- Improved `/sendtochannel` and `/sendtoall` commands, using new message helpers.
 ### Deprecated
 ### Removed
 ### Fixed

--- a/src/Commands/AdminCommands/SendtoallCommand.php
+++ b/src/Commands/AdminCommands/SendtoallCommand.php
@@ -38,7 +38,7 @@ class SendtoallCommand extends AdminCommand
     /**
      * @var string
      */
-    protected $version = '1.4.0';
+    protected $version = '1.5.0';
 
     /**
      * @var bool
@@ -53,67 +53,59 @@ class SendtoallCommand extends AdminCommand
      */
     public function execute()
     {
-        $message = $this->getMessage();
-
-        $chat_id = $message->getChat()->getId();
-        $text    = $message->getText(true);
+        $text = $this->getMessage()->getText(true);
 
         if ($text === '') {
-            $text = 'Write the message to send: /sendtoall <message>';
-        } else {
-            $results = Request::sendToActiveChats(
-                'sendMessage', //callback function to execute (see Request.php methods)
-                ['text' => $text], //Param to evaluate the request
-                [
-                    'groups'      => true,
-                    'supergroups' => true,
-                    'channels'    => false,
-                    'users'       => true,
-                ]
-            );
-
-            $total  = 0;
-            $failed = 0;
-
-            $text = 'Message sent to:' . PHP_EOL;
-
-            /** @var ServerResponse $result */
-            foreach ($results as $result) {
-                $name = '';
-                $type = '';
-                if ($result->isOk()) {
-                    $status = '✔️';
-
-                    /** @var Message $message */
-                    $message = $result->getResult();
-                    $chat    = $message->getChat();
-                    if ($chat->isPrivateChat()) {
-                        $name = $chat->getFirstName();
-                        $type = 'user';
-                    } else {
-                        $name = $chat->getTitle();
-                        $type = 'chat';
-                    }
-                } else {
-                    $status = '✖️';
-                    ++$failed;
-                }
-                ++$total;
-
-                $text .= $total . ') ' . $status . ' ' . $type . ' ' . $name . PHP_EOL;
-            }
-            $text .= 'Delivered: ' . ($total - $failed) . '/' . $total . PHP_EOL;
-
-            if ($total === 0) {
-                $text = 'No users or chats found..';
-            }
+            return $this->replyToChat('Usage: ' . $this->getUsage());
         }
 
-        $data = [
-            'chat_id' => $chat_id,
-            'text'    => $text,
-        ];
+        /** @var ServerResponse[] $results */
+        $results = Request::sendToActiveChats(
+            'sendMessage',     //callback function to execute (see Request.php methods)
+            ['text' => $text], //Param to evaluate the request
+            [
+                'groups'      => true,
+                'supergroups' => true,
+                'channels'    => false,
+                'users'       => true,
+            ]
+        );
 
-        return Request::sendMessage($data);
+        if (empty($results)) {
+            return $this->replyToChat('No users or chats found.');
+        }
+
+        $total  = 0;
+        $failed = 0;
+
+        $text = 'Message sent to:' . PHP_EOL;
+
+        foreach ($results as $result) {
+            $name = '';
+            $type = '';
+            if ($result->isOk()) {
+                $status = '✔️';
+
+                /** @var Message $message */
+                $message = $result->getResult();
+                $chat    = $message->getChat();
+                if ($chat->isPrivateChat()) {
+                    $name = $chat->getFirstName();
+                    $type = 'user';
+                } else {
+                    $name = $chat->getTitle();
+                    $type = 'chat';
+                }
+            } else {
+                $status = '✖️';
+                ++$failed;
+            }
+            ++$total;
+
+            $text .= $total . ') ' . $status . ' ' . $type . ' ' . $name . PHP_EOL;
+        }
+        $text .= 'Delivered: ' . ($total - $failed) . '/' . $total . PHP_EOL;
+
+        return $this->replyToChat($text);
     }
 }


### PR DESCRIPTION
Improve and partly rewrite `/sendtochannel` and `/sendtoall` commands.

It would be ideal to use the message composition of `/sendtochannel` in `/sendtoall` as well and then maybe move them both out of core, what do you guys think?

@php-telegram-bot/developers @Hitmare @bafplus