### PR TITLE
Fix getStickerSet (#836)

### DIFF
--- a/src/Entities/ServerResponse.php
+++ b/src/Entities/ServerResponse.php
@@ -112,6 +112,7 @@ class ServerResponse extends Entity
 
         $result_object_types = [
             'total_count' => 'UserProfilePhotos', //Response from getUserProfilePhotos
+            'stickers'    => 'StickerSet',        //Response from getStickerSet
             'file_id'     => 'File',              //Response from getFile
             'title'       => 'Chat',              //Response from getChat
             'username'    => 'User',              //Response from getMe


### PR DESCRIPTION
Fixed `Request::getStickerSet($data)->getResult()` returning a Chat object. It now returns a StickerSet object as intended.

This fixes #836
