### PR TITLE
Add setting to define custom MySQL port.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Exclamation symbols (:exclamation:) note something of importance e.g. breaking c
 ### Added
 - `ChatAction` class to simplify chat action selection.
 - Telegram Games platform!
+- Ability to set custom MySQL port.
 ### Changed
 - [:exclamation:][unreleased-bc-rename-constants] Rename and ensure no redefinition of constants: `BASE_PATH` -> `TB_BASE_PATH`, `BASE_COMMANDS_PATH` -> `TB_BASE_COMMANDS_PATH`.
 ### Deprecated

--- a/README.md
+++ b/README.md
@@ -272,6 +272,7 @@ $bot_username = 'username_bot';
 
 $mysql_credentials = [
    'host'     => 'localhost',
+   'port'     => 3306, // optional
    'user'     => 'dbuser',
    'password' => 'dbpass',
    'database' => 'dbname',
@@ -412,6 +413,7 @@ If you want to save messages/users/chats for further usage in commands, create a
 ```php
 $mysql_credentials = [
    'host'     => 'localhost',
+   'port'     => 3306, // optional
    'user'     => 'dbuser',
    'password' => 'dbpass',
    'database' => 'dbname',

--- a/src/DB.php
+++ b/src/DB.php
@@ -75,7 +75,11 @@ class DB
             throw new TelegramException('MySQL credentials not provided!');
         }
 
-        $dsn     = 'mysql:host=' . $credentials['host'] . ';dbname=' . $credentials['database'];
+        $dsn = 'mysql:host=' . $credentials['host'] . ';dbname=' . $credentials['database'];
+        if (!empty($credentials['port'])) {
+            $dsn .= ';port=' . $credentials['port'];
+        }
+
         $options = [PDO::MYSQL_ATTR_INIT_COMMAND => 'SET NAMES ' . $encoding];
         try {
             $pdo = new PDO($dsn, $credentials['user'], $credentials['password'], $options);


### PR DESCRIPTION
MySQL credentials array now allows a `port` parameter to be set:
```php
$mysql_credentials = [
   'host'     => 'localhost',
   'port'     => 3306,        // new optional parameter
   'user'     => 'dbuser',
   'password' => 'dbpass',
   'database' => 'dbname',
];
```

Fixes #857 