### PR TITLE
Bot API 4.0 - NO Telegram Passport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 Exclamation symbols (:exclamation:) note something of importance e.g. breaking changes. Click them to learn more.
 
 ## [Unreleased]
+:exclamation: After updating to this version, you will need to execute the [SQL migration script][unreleased-sql-migration] on your database.
 ### Added
+- Bot API 4.0 (without Passport)
 ### Changed
+- [:exclamation:][unreleased-bc-move-animation-out-of-games-namespace] Move Animation entity out of Games namespace.
 ### Deprecated
 ### Removed
 ### Fixed
@@ -213,6 +216,8 @@ Exclamation symbols (:exclamation:) note something of importance e.g. breaking c
 ### Deprecated
 - Move `hideKeyboard` to `removeKeyboard`.
 
+[unreleased-sql-migration]: https://github.com/php-telegram-bot/core/tree/master/utils/db-schema-update/0.54.0-unreleased.sql
+[unreleased-bc-move-animation-out-of-games-namespace]: https://github.com/php-telegram-bot/core/wiki/Breaking-backwards-compatibility#move-animation-out-of-games-namespace
 [0.54.0-sql-migration]: https://github.com/php-telegram-bot/core/tree/master/utils/db-schema-update/0.53.0-0.54.0.sql
 [0.54.0-bc-rename-constants]: https://github.com/php-telegram-bot/core/wiki/Breaking-backwards-compatibility#rename-constants
 [0.53.0-sql-migration]: https://github.com/php-telegram-bot/core/tree/master/utils/db-schema-update/0.52.0-0.53.0.sql

--- a/README.md
+++ b/README.md
@@ -364,7 +364,7 @@ $result = Request::sendPhoto([
 ]);
 ```
 
-*sendAudio*, *sendDocument*, *sendSticker*, *sendVideo*, *sendVoice* and *sendVideoNote* all work in the same way, just check the [API documentation](https://core.telegram.org/bots/api#sendphoto) for the exact usage.
+*sendAudio*, *sendDocument*, *sendAnimation*, *sendSticker*, *sendVideo*, *sendVoice* and *sendVideoNote* all work in the same way, just check the [API documentation](https://core.telegram.org/bots/api#sendphoto) for the exact usage.
 See the [*ImageCommand.php*][ImageCommand.php] for a full example.
 
 #### Send Chat Action

--- a/src/DB.php
+++ b/src/DB.php
@@ -829,7 +829,7 @@ class DB
                 (
                     `id`, `user_id`, `chat_id`, `date`, `forward_from`, `forward_from_chat`, `forward_from_message_id`,
                     `forward_date`, `reply_to_chat`, `reply_to_message`, `media_group_id`, `text`, `entities`, `audio`, `document`,
-                    `game`, `photo`, `sticker`, `video`, `voice`, `video_note`, `caption`, `contact`,
+                    `animation`, `game`, `photo`, `sticker`, `video`, `voice`, `video_note`, `caption`, `contact`,
                     `location`, `venue`, `new_chat_members`, `left_chat_member`,
                     `new_chat_title`,`new_chat_photo`, `delete_chat_photo`, `group_chat_created`,
                     `supergroup_chat_created`, `channel_chat_created`,
@@ -837,7 +837,7 @@ class DB
                 ) VALUES (
                     :message_id, :user_id, :chat_id, :date, :forward_from, :forward_from_chat, :forward_from_message_id,
                     :forward_date, :reply_to_chat, :reply_to_message, :media_group_id, :text, :entities, :audio, :document,
-                    :game, :photo, :sticker, :video, :voice, :video_note, :caption, :contact,
+                    :animation, :game, :photo, :sticker, :video, :voice, :video_note, :caption, :contact,
                     :location, :venue, :new_chat_members, :left_chat_member,
                     :new_chat_title, :new_chat_photo, :delete_chat_photo, :group_chat_created,
                     :supergroup_chat_created, :channel_chat_created,
@@ -881,6 +881,7 @@ class DB
             $sth->bindValue(':entities', $t = self::entitiesArrayToJson($message->getEntities(), null));
             $sth->bindValue(':audio', $message->getAudio());
             $sth->bindValue(':document', $message->getDocument());
+            $sth->bindValue(':animation', $message->getAnimation());
             $sth->bindValue(':game', $message->getGame());
             $sth->bindValue(':photo', $t = self::entitiesArrayToJson($message->getPhoto(), null));
             $sth->bindValue(':sticker', $message->getSticker());

--- a/src/Entities/Animation.php
+++ b/src/Entities/Animation.php
@@ -8,9 +8,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Longman\TelegramBot\Entities\Games;
-
-use Longman\TelegramBot\Entities\Entity;
+namespace Longman\TelegramBot\Entities;
 
 /**
  * Class Animation
@@ -20,6 +18,9 @@ use Longman\TelegramBot\Entities\Entity;
  * @link https://core.telegram.org/bots/api#animation
  *
  * @method string    getFileId()   Unique file identifier
+ * @method int       getWidth()    Video width as defined by sender
+ * @method int       getHeight()   Video height as defined by sender
+ * @method int       getDuration() Duration of the video in seconds as defined by sender
  * @method PhotoSize getThumb()    Optional. Animation thumbnail as defined by sender
  * @method string    getFileName() Optional. Original animation filename as defined by sender
  * @method string    getMimeType() Optional. MIME type of the file as defined by sender

--- a/src/Entities/Audio.php
+++ b/src/Entities/Audio.php
@@ -15,14 +15,23 @@ namespace Longman\TelegramBot\Entities;
  *
  * @link https://core.telegram.org/bots/api#audio
  *
- * @method string getFileId()    Unique identifier for this file
- * @method int    getDuration()  Duration of the audio in seconds as defined by sender
- * @method string getPerformer() Optional. Performer of the audio as defined by sender or by audio tags
- * @method string getTitle()     Optional. Title of the audio as defined by sender or by audio tags
- * @method string getMimeType()  Optional. MIME type of the file as defined by sender
- * @method int    getFileSize()  Optional. File size
+ * @method string    getFileId()    Unique identifier for this file
+ * @method int       getDuration()  Duration of the audio in seconds as defined by sender
+ * @method string    getPerformer() Optional. Performer of the audio as defined by sender or by audio tags
+ * @method string    getTitle()     Optional. Title of the audio as defined by sender or by audio tags
+ * @method string    getMimeType()  Optional. MIME type of the file as defined by sender
+ * @method int       getFileSize()  Optional. File size
+ * @method PhotoSize getThumb()     Optional. Thumbnail of the album cover to which the music file belongs
  */
 class Audio extends Entity
 {
-
+    /**
+     * {@inheritdoc}
+     */
+    protected function subEntities()
+    {
+        return [
+            'thumb' => PhotoSize::class,
+        ];
+    }
 }

--- a/src/Entities/Contact.php
+++ b/src/Entities/Contact.php
@@ -19,6 +19,7 @@ namespace Longman\TelegramBot\Entities;
  * @method string getFirstName()   Contact's first name
  * @method string getLastName()    Optional. Contact's last name
  * @method int    getUserId()      Optional. Contact's user identifier in Telegram
+ * @method string getVcard()       Optional. Additional data about the contact in the form of a vCard
  */
 class Contact extends Entity
 {

--- a/src/Entities/InlineQuery/InlineQueryResultContact.php
+++ b/src/Entities/InlineQuery/InlineQueryResultContact.php
@@ -37,6 +37,7 @@ use Longman\TelegramBot\Entities\InputMessageContent\InputMessageContent;
  * @method string               getPhoneNumber()         Contact's phone number
  * @method string               getFirstName()           Contact's first name
  * @method string               getLastName()            Optional. Contact's last name
+ * @method string               getVcard()               Optional. Additional data about the contact in the form of a vCard, 0-2048 bytes
  * @method InlineKeyboard       getReplyMarkup()         Optional. Inline keyboard attached to the message
  * @method InputMessageContent  getInputMessageContent() Optional. Content of the message to be sent instead of the contact
  * @method string               getThumbUrl()            Optional. Url of the thumbnail for the result
@@ -47,6 +48,7 @@ use Longman\TelegramBot\Entities\InputMessageContent\InputMessageContent;
  * @method $this setPhoneNumber(string $phone_number)                               Contact's phone number
  * @method $this setFirstName(string $first_name)                                   Contact's first name
  * @method $this setLastName(string $last_name)                                     Optional. Contact's last name
+ * @method $this setVcard(string $vcard)                                            Optional. Additional data about the contact in the form of a vCard, 0-2048 bytes
  * @method $this setReplyMarkup(InlineKeyboard $reply_markup)                       Optional. Inline keyboard attached to the message
  * @method $this setInputMessageContent(InputMessageContent $input_message_content) Optional. Content of the message to be sent instead of the contact
  * @method $this setThumbUrl(string $thumb_url)                                     Optional. Url of the thumbnail for the result

--- a/src/Entities/InlineQuery/InlineQueryResultVenue.php
+++ b/src/Entities/InlineQuery/InlineQueryResultVenue.php
@@ -41,6 +41,7 @@ use Longman\TelegramBot\Entities\InputMessageContent\InputMessageContent;
  * @method string               getTitle()               Title of the venue
  * @method string               getAddress()             Address of the venue
  * @method string               getFoursquareId()        Optional. Foursquare identifier of the venue if known
+ * @method string               getFoursquareType()      Optional. Foursquare type of the venue, if known. (For example, “arts_entertainment/default”, “arts_entertainment/aquarium” or “food/icecream”.)
  * @method InlineKeyboard       getReplyMarkup()         Optional. Inline keyboard attached to the message
  * @method InputMessageContent  getInputMessageContent() Optional. Content of the message to be sent instead of the venue
  * @method string               getThumbUrl()            Optional. Url of the thumbnail for the result
@@ -53,6 +54,7 @@ use Longman\TelegramBot\Entities\InputMessageContent\InputMessageContent;
  * @method $this setTitle(string $title)                                            Title of the venue
  * @method $this setAddress(string $address)                                        Address of the venue
  * @method $this setFoursquareId(string $foursquare_id)                             Optional. Foursquare identifier of the venue if known
+ * @method $this setFoursquareType(string $foursquare_type)                         Optional. Foursquare type of the venue, if known. (For example, “arts_entertainment/default”, “arts_entertainment/aquarium” or “food/icecream”.)
  * @method $this setReplyMarkup(InlineKeyboard $reply_markup)                       Optional. Inline keyboard attached to the message
  * @method $this setInputMessageContent(InputMessageContent $input_message_content) Optional. Content of the message to be sent instead of the venue
  * @method $this setThumbUrl(string $thumb_url)                                     Optional. Url of the thumbnail for the result

--- a/src/Entities/InputMedia/InputMediaAnimation.php
+++ b/src/Entities/InputMedia/InputMediaAnimation.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * This file is part of the TelegramBot package.
+ *
+ * (c) Avtandil Kikabidze aka LONGMAN <akalongman@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Longman\TelegramBot\Entities\InputMedia;
+
+use Longman\TelegramBot\Entities\Entity;
+
+/**
+ * Class InputMediaAnimation
+ *
+ * @link https://core.telegram.org/bots/api#inputmediaanimation
+ *
+ * <code>
+ * $data = [
+ *   'media'      => '123abc',
+ *   'thumb'      => '456def',
+ *   'caption'    => '*Animation* caption',
+ *   'parse_mode' => 'markdown',
+ *   'width'      => 200,
+ *   'height'     => 150,
+ *   'duration'   => 11,
+ * ];
+ * </code>
+ *
+ * @method string getType()      Type of the result, must be animation
+ * @method string getMedia()     File to send. Pass a file_id to send a file that exists on the Telegram servers (recommended), pass an HTTP URL for Telegram to get a file from the Internet, or pass “attach://<file_attach_name>” to upload a new one using multipart/form-data under <file_attach_name> name. More info on Sending Files »
+ * @method string getThumb()     Optional. Thumbnail of the file sent. The thumbnail should be in JPEG format and less than 200 kB in size. A thumbnail‘s width and height should not exceed 90. Ignored if the file is not uploaded using multipart/form-data. Thumbnails can’t be reused and can be only uploaded as a new file, so you can pass “attach://<file_attach_name>” if the thumbnail was uploaded using multipart/form-data under <file_attach_name>. More info on Sending Files »
+ * @method string getCaption()   Optional. Caption of the animation to be sent, 0-200 characters
+ * @method string getParseMode() Optional. Send Markdown or HTML, if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in the media caption.
+ * @method int    getWidth()     Optional. Animation width
+ * @method int    getHeight()    Optional. Animation height
+ * @method int    getDuration()  Optional. Animation duration
+ *
+ * @method $this setMedia(string $media)           File to send. Pass a file_id to send a file that exists on the Telegram servers (recommended), pass an HTTP URL for Telegram to get a file from the Internet, or pass “attach://<file_attach_name>” to upload a new one using multipart/form-data under <file_attach_name> name. More info on Sending Files »
+ * @method $this setThumb(string $thumb) Optional. Thumbnail of the file sent. The thumbnail should be in JPEG format and less than 200 kB in size. A thumbnail‘s width and height should not exceed 90. Ignored if the file is not uploaded using multipart/form-data. Thumbnails can’t be reused and can be only uploaded as a new file, so you can pass “attach://<file_attach_name>” if the thumbnail was uploaded using multipart/form-data under <file_attach_name>. More info on Sending Files »
+ * @method $this setCaption(string $caption)       Optional. Caption of the animation to be sent, 0-200 characters
+ * @method $this setParseMode(string $parse_mode)  Optional. Send Markdown or HTML, if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in the media caption.
+ * @method $this setWidth(int $width)              Optional. Animation width
+ * @method $this setHeight(int $height)            Optional. Animation height
+ * @method $this setDuration(int $duration)        Optional. Animation duration
+ */
+class InputMediaAnimation extends Entity implements InputMedia
+{
+    /**
+     * InputMediaAnimation constructor
+     *
+     * @param array $data
+     *
+     * @throws \Longman\TelegramBot\Exception\TelegramException
+     */
+    public function __construct(array $data = [])
+    {
+        $data['type'] = 'animation';
+        parent::__construct($data);
+    }
+}

--- a/src/Entities/InputMedia/InputMediaAudio.php
+++ b/src/Entities/InputMedia/InputMediaAudio.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * This file is part of the TelegramBot package.
+ *
+ * (c) Avtandil Kikabidze aka LONGMAN <akalongman@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Longman\TelegramBot\Entities\InputMedia;
+
+use Longman\TelegramBot\Entities\Entity;
+
+/**
+ * Class InputMediaAudio
+ *
+ * @link https://core.telegram.org/bots/api#inputmediaaudio
+ *
+ * <code>
+ * $data = [
+ *   'media'      => '123abc',
+ *   'thumb'      => '456def',
+ *   'caption'    => '*Audio* caption',
+ *   'parse_mode' => 'markdown',
+ *   'duration'   => 42,
+ *   'performer'  => 'John Doe',
+ *   'title'      => 'The Song',
+ * ];
+ * </code>
+ *
+ * @method string getType()      Type of the result, must be audio
+ * @method string getMedia()     File to send. Pass a file_id to send a file that exists on the Telegram servers (recommended), pass an HTTP URL for Telegram to get a file from the Internet, or pass "attach://<file_attach_name>" to upload a new one using multipart/form-data under <file_attach_name> name.
+ * @method string getThumb()     Optional. Thumbnail of the file sent. The thumbnail should be in JPEG format and less than 200 kB in size. A thumbnail‘s width and height should not exceed 90. Ignored if the file is not uploaded using multipart/form-data. Thumbnails can’t be reused and can be only uploaded as a new file, so you can pass “attach://<file_attach_name>” if the thumbnail was uploaded using multipart/form-data under <file_attach_name>. More info on Sending Files »
+ * @method string getCaption()   Optional. Caption of the audio to be sent, 0-200 characters
+ * @method string getParseMode() Optional. Send Markdown or HTML, if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in the media caption.
+ * @method int    getDuration()  Optional. Duration of the audio in seconds
+ * @method string getPerformer() Optional. Performer of the audio
+ * @method string getTitle()     Optional. Title of the audio
+ *
+ * @method $this setMedia(string $media)          File to send. Pass a file_id to send a file that exists on the Telegram servers (recommended), pass an HTTP URL for Telegram to get a file from the Internet, or pass "attach://<file_attach_name>" to upload a new one using multipart/form-data under <file_attach_name> name.
+ * @method $this setThumb(string $thumb)          Optional. Thumbnail of the file sent. The thumbnail should be in JPEG format and less than 200 kB in size. A thumbnail‘s width and height should not exceed 90. Ignored if the file is not uploaded using multipart/form-data. Thumbnails can’t be reused and can be only uploaded as a new file, so you can pass “attach://<file_attach_name>” if the thumbnail was uploaded using multipart/form-data under <file_attach_name>. More info on Sending Files »
+ * @method $this setCaption(string $caption)      Optional. Caption of the audio to be sent, 0-200 characters
+ * @method $this setParseMode(string $parse_mode) Optional. Send Markdown or HTML, if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in the media caption.
+ * @method $this setDuration(int $duration)       Optional. Duration of the audio in seconds
+ * @method $this setPerformer(string $performer)  Optional. Performer of the audio
+ * @method $this setTitle(string $title)          Optional. Title of the audio
+ */
+class InputMediaAudio extends Entity implements InputMedia
+{
+    /**
+     * InputMediaAudio constructor
+     *
+     * @param array $data
+     *
+     * @throws \Longman\TelegramBot\Exception\TelegramException
+     */
+    public function __construct(array $data = [])
+    {
+        $data['type'] = 'audio';
+        parent::__construct($data);
+    }
+}

--- a/src/Entities/InputMedia/InputMediaDocument.php
+++ b/src/Entities/InputMedia/InputMediaDocument.php
@@ -13,31 +13,34 @@ namespace Longman\TelegramBot\Entities\InputMedia;
 use Longman\TelegramBot\Entities\Entity;
 
 /**
- * Class InputMediaPhoto
+ * Class InputMediaDocument
  *
- * @link https://core.telegram.org/bots/api#inputmediaphoto
+ * @link https://core.telegram.org/bots/api#inputmediadocument
  *
  * <code>
  * $data = [
  *   'media'      => '123abc',
- *   'caption'    => '*Photo* caption',
+ *   'thumb'      => '456def',
+ *   'caption'    => '*Document* caption',
  *   'parse_mode' => 'markdown',
  * ];
  * </code>
  *
- * @method string getType()      Type of the result, must be photo
+ * @method string getType()      Type of the result, must be document
  * @method string getMedia()     File to send. Pass a file_id to send a file that exists on the Telegram servers (recommended), pass an HTTP URL for Telegram to get a file from the Internet, or pass "attach://<file_attach_name>" to upload a new one using multipart/form-data under <file_attach_name> name.
- * @method string getCaption()   Optional. Caption of the photo to be sent, 0-200 characters
+ * @method string getThumb()     Optional. Thumbnail of the file sent. The thumbnail should be in JPEG format and less than 200 kB in size. A thumbnail‘s width and height should not exceed 90. Ignored if the file is not uploaded using multipart/form-data. Thumbnails can’t be reused and can be only uploaded as a new file, so you can pass “attach://<file_attach_name>” if the thumbnail was uploaded using multipart/form-data under <file_attach_name>. More info on Sending Files »
+ * @method string getCaption()   Optional. Caption of the document to be sent, 0-200 characters
  * @method string getParseMode() Optional. Send Markdown or HTML, if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in the media caption.
  *
  * @method $this setMedia(string $media)          File to send. Pass a file_id to send a file that exists on the Telegram servers (recommended), pass an HTTP URL for Telegram to get a file from the Internet, or pass "attach://<file_attach_name>" to upload a new one using multipart/form-data under <file_attach_name> name.
- * @method $this setCaption(string $caption)      Optional. Caption of the photo to be sent, 0-200 characters
+ * @method $this setThumb(string $thumb)          Optional. Thumbnail of the file sent. The thumbnail should be in JPEG format and less than 200 kB in size. A thumbnail‘s width and height should not exceed 90. Ignored if the file is not uploaded using multipart/form-data. Thumbnails can’t be reused and can be only uploaded as a new file, so you can pass “attach://<file_attach_name>” if the thumbnail was uploaded using multipart/form-data under <file_attach_name>. More info on Sending Files »
+ * @method $this setCaption(string $caption)      Optional. Caption of the document to be sent, 0-200 characters
  * @method $this setParseMode(string $parse_mode) Optional. Send Markdown or HTML, if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in the media caption.
  */
-class InputMediaPhoto extends Entity implements InputMedia
+class InputMediaDocument extends Entity implements InputMedia
 {
     /**
-     * InputMediaPhoto constructor
+     * InputMediaDocument constructor
      *
      * @param array $data
      *
@@ -45,7 +48,7 @@ class InputMediaPhoto extends Entity implements InputMedia
      */
     public function __construct(array $data = [])
     {
-        $data['type'] = 'photo';
+        $data['type'] = 'document';
         parent::__construct($data);
     }
 }

--- a/src/Entities/InputMedia/InputMediaVideo.php
+++ b/src/Entities/InputMedia/InputMediaVideo.php
@@ -20,24 +20,30 @@ use Longman\TelegramBot\Entities\Entity;
  * <code>
  * $data = [
  *   'media'              => '123abc',
- *   'caption'            => 'Video caption (streamable)',
+ *   'thumb'              => '456def',
+ *   'caption'            => '*Video* caption (streamable)',
+ *   'parse_mode'         => 'markdown',
  *   'width'              => 800,
  *   'height'             => 600,
  *   'duration'           => 42,
- *   'supports_streaming' => true
+ *   'supports_streaming' => true,
  * ];
  * </code>
  *
  * @method string getType()              Type of the result, must be video
  * @method string getMedia()             File to send. Pass a file_id to send a file that exists on the Telegram servers (recommended), pass an HTTP URL for Telegram to get a file from the Internet, or pass "attach://<file_attach_name>" to upload a new one using multipart/form-data under <file_attach_name> name.
+ * @method string getThumb()             Optional. Thumbnail of the file sent. The thumbnail should be in JPEG format and less than 200 kB in size. A thumbnail‘s width and height should not exceed 90. Ignored if the file is not uploaded using multipart/form-data. Thumbnails can’t be reused and can be only uploaded as a new file, so you can pass “attach://<file_attach_name>” if the thumbnail was uploaded using multipart/form-data under <file_attach_name>. More info on Sending Files »
  * @method string getCaption()           Optional. Caption of the video to be sent, 0-200 characters
+ * @method string getParseMode()         Optional. Send Markdown or HTML, if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in the media caption.
  * @method int    getWidth()             Optional. Video width
  * @method int    getHeight()            Optional. Video height
  * @method int    getDuration()          Optional. Video duration
  * @method bool   getSupportsStreaming() Optional. Pass True, if the uploaded video is suitable for streaming
  *
  * @method $this setMedia(string $media)                        File to send. Pass a file_id to send a file that exists on the Telegram servers (recommended), pass an HTTP URL for Telegram to get a file from the Internet, or pass "attach://<file_attach_name>" to upload a new one using multipart/form-data under <file_attach_name> name.
+ * @method $this setThumb(string $thumb)                        Optional. Thumbnail of the file sent. The thumbnail should be in JPEG format and less than 200 kB in size. A thumbnail‘s width and height should not exceed 90. Ignored if the file is not uploaded using multipart/form-data. Thumbnails can’t be reused and can be only uploaded as a new file, so you can pass “attach://<file_attach_name>” if the thumbnail was uploaded using multipart/form-data under <file_attach_name>. More info on Sending Files »
  * @method $this setCaption(string $caption)                    Optional. Caption of the video to be sent, 0-200 characters
+ * @method $this setParseMode(string $parse_mode)               Optional. Send Markdown or HTML, if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in the media caption.
  * @method $this setWidth(int $width)                           Optional. Video width
  * @method $this setHeight(int $height)                         Optional. Video height
  * @method $this setDuration(int $duration)                     Optional. Video duration

--- a/src/Entities/InputMessageContent/InputContactMessageContent.php
+++ b/src/Entities/InputMessageContent/InputContactMessageContent.php
@@ -22,16 +22,19 @@ use Longman\TelegramBot\Entities\InlineQuery\InlineEntity;
  *   'phone_number' => '',
  *   'first_name'   => '',
  *   'last_name'    => '',
+ *   'vcard'        => '',
  * ];
  * </code>
  *
  * @method string getPhoneNumber() Contact's phone number
  * @method string getFirstName()   Contact's first name
  * @method string getLastName()    Optional. Contact's last name
+ * @method string getVcard()       Optional. Additional data about the contact in the form of a vCard, 0-2048 bytes
  *
  * @method $this setPhoneNumber(string $phone_number) Contact's phone number
  * @method $this setFirstName(string $first_name)     Contact's first name
  * @method $this setLastName(string $last_name)       Optional. Contact's last name
+ * @method $this setVcard(string $vcard)              Optional. Additional data about the contact in the form of a vCard, 0-2048 bytes
  */
 class InputContactMessageContent extends InlineEntity implements InputMessageContent
 {

--- a/src/Entities/InputMessageContent/InputVenueMessageContent.php
+++ b/src/Entities/InputMessageContent/InputVenueMessageContent.php
@@ -19,25 +19,28 @@ use Longman\TelegramBot\Entities\InlineQuery\InlineEntity;
  *
  * <code>
  * $data = [
- *   'latitude'      => 36.0338,
- *   'longitude'     => 71.8601,
- *   'title'         => '',
- *   'address'       => '',
- *   'foursquare_id' => '',
+ *   'latitude'        => 36.0338,
+ *   'longitude'       => 71.8601,
+ *   'title'           => '',
+ *   'address'         => '',
+ *   'foursquare_id'   => '',
+ *   'foursquare_type' => '',
  * ];
  * </code>
  *
- * @method float  getLatitude()          Latitude of the location in degrees
- * @method float  getLongitude()         Longitude of the location in degrees
- * @method string getTitle()             Name of the venue
- * @method string getAddress()           Address of the venue
- * @method string getFoursquareIdTitle() Optional. Foursquare identifier of the venue, if known
+ * @method float  getLatitude()       Latitude of the location in degrees
+ * @method float  getLongitude()      Longitude of the location in degrees
+ * @method string getTitle()          Name of the venue
+ * @method string getAddress()        Address of the venue
+ * @method string getFoursquareId()   Optional. Foursquare identifier of the venue, if known
+ * @method string getFoursquareType() Optional. Foursquare type of the venue, if known. (For example, “arts_entertainment/default”, “arts_entertainment/aquarium” or “food/icecream”.)
  *
- * @method $this setLatitude(float $latitude)                      Latitude of the location in degrees
- * @method $this setLongitude(float $longitude)                    Longitude of the location in degrees
- * @method $this setTitle(string $title)                           Name of the venue
- * @method $this setAddress(string $address)                       Address of the venue
- * @method $this setFoursquareIdTitle(string $foursquare_id_title) Optional. Foursquare identifier of the venue, if known
+ * @method $this setLatitude(float $latitude)               Latitude of the location in degrees
+ * @method $this setLongitude(float $longitude)             Longitude of the location in degrees
+ * @method $this setTitle(string $title)                    Name of the venue
+ * @method $this setAddress(string $address)                Address of the venue
+ * @method $this setFoursquareId(string $foursquare_id)     Optional. Foursquare identifier of the venue, if known
+ * @method $this setFoursquareType(string $foursquare_type) Optional. Foursquare type of the venue, if known. (For example, “arts_entertainment/default”, “arts_entertainment/aquarium” or “food/icecream”.)
  */
 class InputVenueMessageContent extends InlineEntity implements InputMessageContent
 {

--- a/src/Entities/Message.php
+++ b/src/Entities/Message.php
@@ -34,6 +34,7 @@ use Longman\TelegramBot\Entities\Payments\SuccessfulPayment;
  * @method string            getAuthorSignature()       Optional. Signature of the post author for messages in channels
  * @method Audio             getAudio()                 Optional. Message is an audio file, information about the file
  * @method Document          getDocument()              Optional. Message is a general file, information about the file
+ * @method Animation         getAnimation()             Optional. Message is an animation, information about the animation. For backward compatibility, when this field is set, the document field will also be set
  * @method Game              getGame()                  Optional. Message is a game, information about the game.
  * @method Sticker           getSticker()               Optional. Message is a sticker, information about the sticker
  * @method Video             getVideo()                 Optional. Message is a video, information about the video
@@ -73,6 +74,7 @@ class Message extends Entity
             'caption_entities'   => MessageEntity::class,
             'audio'              => Audio::class,
             'document'           => Document::class,
+            'animation'          => Animation::class,
             'game'               => Game::class,
             'photo'              => PhotoSize::class,
             'sticker'            => Sticker::class,
@@ -280,6 +282,8 @@ class Message extends Entity
             'text',
             'audio',
             'document',
+            'animation',
+            'game',
             'photo',
             'sticker',
             'video',

--- a/src/Entities/MessageEntity.php
+++ b/src/Entities/MessageEntity.php
@@ -15,7 +15,7 @@ namespace Longman\TelegramBot\Entities;
  *
  * @link https://core.telegram.org/bots/api#messageentity
  *
- * @method string getType()   Type of the entity. Can be mention (@username), hashtag, bot_command, url, email, bold (bold text), italic (italic text), code (monowidth string), pre (monowidth block), text_link (for clickable text URLs), text_mention (for users without usernames)
+ * @method string getType()   Type of the entity. Can be mention (@username), hashtag, cashtag, bot_command, url, email, phone_number, bold (bold text), italic (italic text), code (monowidth string), pre (monowidth block), text_link (for clickable text URLs), text_mention (for users without usernames)
  * @method int    getOffset() Offset in UTF-16 code units to the start of the entity
  * @method int    getLength() Length of the entity in UTF-16 code units
  * @method string getUrl()    Optional. For "text_link" only, url that will be opened after user taps on the text

--- a/src/Entities/Venue.php
+++ b/src/Entities/Venue.php
@@ -15,10 +15,11 @@ namespace Longman\TelegramBot\Entities;
  *
  * @link https://core.telegram.org/bots/api#venue
  *
- * @method Location getLocation()     Venue location
- * @method string   getTitle()        Name of the venue
- * @method string   getAddress()      Address of the venue
- * @method string   getFoursquareId() Optional. Foursquare identifier of the venue
+ * @method Location getLocation()       Venue location
+ * @method string   getTitle()          Name of the venue
+ * @method string   getAddress()        Address of the venue
+ * @method string   getFoursquareId()   Optional. Foursquare identifier of the venue
+ * @method string   getFoursquareType() Optional. Foursquare type of the venue. (For example, “arts_entertainment/default”, “arts_entertainment/aquarium” or “food/icecream”.)
  */
 class Venue extends Entity
 {

--- a/src/Request.php
+++ b/src/Request.php
@@ -31,6 +31,7 @@ use Longman\TelegramBot\Exception\TelegramException;
  * @method static ServerResponse sendDocument(array $data)            Use this method to send general files. On success, the sent Message is returned. Bots can currently send files of any type of up to 50 MB in size, this limit may be changed in the future.
  * @method static ServerResponse sendSticker(array $data)             Use this method to send .webp stickers. On success, the sent Message is returned.
  * @method static ServerResponse sendVideo(array $data)               Use this method to send video files, Telegram clients support mp4 videos (other formats may be sent as Document). On success, the sent Message is returned. Bots can currently send video files of up to 50 MB in size, this limit may be changed in the future.
+ * @method static ServerResponse sendAnimation(array $data)           Use this method to send animation files (GIF or H.264/MPEG-4 AVC video without sound). On success, the sent Message is returned. Bots can currently send animation files of up to 50 MB in size, this limit may be changed in the future.
  * @method static ServerResponse sendVoice(array $data)               Use this method to send audio files, if you want Telegram clients to display the file as a playable voice message. For this to work, your audio must be in an .ogg file encoded with OPUS (other formats may be sent as Audio or Document). On success, the sent Message is returned. Bots can currently send voice messages of up to 50 MB in size, this limit may be changed in the future.
  * @method static ServerResponse sendVideoNote(array $data)           Use this method to send video messages. On success, the sent Message is returned.
  * @method static ServerResponse sendMediaGroup(array $data)          Use this method to send a group of photos or videos as an album. On success, an array of the sent Messages is returned.
@@ -145,6 +146,7 @@ class Request
         'sendDocument',
         'sendSticker',
         'sendVideo',
+        'sendAnimation',
         'sendVoice',
         'sendVideoNote',
         'sendMediaGroup',
@@ -668,6 +670,7 @@ class Request
                 'sendDocument',
                 'sendSticker',
                 'sendVideo',
+                'sendAnimation',
                 'sendVoice',
                 'sendVideoNote',
                 'sendMediaGroup',

--- a/structure.sql
+++ b/structure.sql
@@ -81,6 +81,7 @@ CREATE TABLE IF NOT EXISTS `message` (
   `entities` TEXT COMMENT 'For text messages, special entities like usernames, URLs, bot commands, etc. that appear in the text',
   `audio` TEXT COMMENT 'Audio object. Message is an audio file, information about the file',
   `document` TEXT COMMENT 'Document object. Message is a general file, information about the file',
+  `animation` TEXT COMMENT 'Optional. Message is an animation, information about the animation',
   `game` TEXT COMMENT 'Game object. Message is a game, information about the game',
   `photo` TEXT COMMENT 'Array of PhotoSize objects. Message is a photo, available sizes of the photo',
   `sticker` TEXT COMMENT 'Sticker object. Message is a sticker, information about the sticker',

--- a/utils/db-schema-update/0.54.0-unreleased.sql
+++ b/utils/db-schema-update/0.54.0-unreleased.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `message` ADD COLUMN `animation` TEXT NULL COMMENT 'Optional. Message is an animation, information about the animation' AFTER `document`;


### PR DESCRIPTION
This PR adds all changes from Bot API 4.0, except the Telegram Passport things, which will be done as a separate PR.

Part of #869 