### PR TITLE
Messages with type of contact now can be handled by ContactCommand.

### DIFF
--- a/src/Telegram.php
+++ b/src/Telegram.php
@@ -481,6 +481,7 @@ class Telegram
                 'pinned_message',
                 'invoice',
                 'successful_payment',
+                'contact',
             ], true)
             ) {
                 $command = $this->getCommandFromType($type);


### PR DESCRIPTION
Fixes #920 
Contact type messages can now be handles if `ContactCommand` defined 