### PR TITLE
Possible fix for #917

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Exclamation symbols (:exclamation:) note something of importance e.g. breaking c
 - Botan.io service has been discontinued.
 ### Removed
 ### Fixed
+- Constraint errors in `/cleanup` command.
 ### Security
 
 ## [0.55.1] - 2019-01-06

--- a/src/Commands/AdminCommands/CleanupCommand.php
+++ b/src/Commands/AdminCommands/CleanupCommand.php
@@ -302,11 +302,9 @@ class CleanupCommand extends AdminCommand
         if (in_array('message', $tables_to_clean, true)) {
             $queries[] = sprintf(
                 'DELETE FROM `%1$s`
-                WHERE id IN
-                 (
-                     SELECT id
-                     FROM
-                     (
+                WHERE id IN (
+                    SELECT id
+                    FROM (
                         SELECT id
                         FROM  `message`
                         WHERE `date` < \'%2$s\'
@@ -321,6 +319,11 @@ class CleanupCommand extends AdminCommand
                             WHERE `message_id` = `%1$s`.`id`
                           )
                           AND `id` NOT IN (
+                            SELECT `message_id`
+                            FROM `%5$s`
+                            WHERE `message_id` = `%1$s`.`id`
+                          )
+                          AND `id` NOT IN (
                             SELECT a.`reply_to_message` FROM `%1$s` a
                             INNER JOIN `%1$s` b ON b.`id` = a.`reply_to_message` AND b.`chat_id` = a.`reply_to_chat`
                           )
@@ -330,6 +333,7 @@ class CleanupCommand extends AdminCommand
             ',
                 TB_MESSAGE,
                 $clean_older_than['message'],
+                TB_EDITED_MESSAGE,
                 TB_TELEGRAM_UPDATE,
                 TB_CALLBACK_QUERY
             );

--- a/src/Commands/AdminCommands/CleanupCommand.php
+++ b/src/Commands/AdminCommands/CleanupCommand.php
@@ -164,6 +164,7 @@ class CleanupCommand extends AdminCommand
                     SELECT `id`
                     FROM `%4$s`
                     WHERE `chat_id` = `%4$s`.`id`
+                    AND `updated_at` < \'%1$s\'
                   )
                   AND (
                     `message_id` IS NOT NULL
@@ -301,17 +302,31 @@ class CleanupCommand extends AdminCommand
         if (in_array('message', $tables_to_clean, true)) {
             $queries[] = sprintf(
                 'DELETE FROM `%1$s`
-                WHERE `date` < \'%2$s\'
-                  AND `id` NOT IN (
-                    SELECT `message_id`
-                    FROM `%3$s`
-                    WHERE `message_id` = `%1$s`.`id`
-                  )
-                  AND `id` NOT IN (
-                    SELECT `message_id`
-                    FROM `%4$s`
-                    WHERE `message_id` = `%1$s`.`id`
-                  )
+                WHERE id IN
+                 (
+                     SELECT id
+                     FROM
+                     (
+                        SELECT id
+                        FROM  `message`
+                        WHERE `date` < \'%2$s\'
+                          AND `id` NOT IN (
+                            SELECT `message_id`
+                            FROM `%3$s`
+                            WHERE `message_id` = `%1$s`.`id`
+                          )
+                          AND `id` NOT IN (
+                            SELECT `message_id`
+                            FROM `%4$s`
+                            WHERE `message_id` = `%1$s`.`id`
+                          )
+                          AND `id` NOT IN (
+                            SELECT a.`reply_to_message` FROM `%1$s` a
+                            INNER JOIN `%1$s` b ON b.`id` = a.`reply_to_message` AND b.`chat_id` = a.`reply_to_chat`
+                          )
+                        ORDER BY `id` DESC
+                     ) a
+                 )
             ',
                 TB_MESSAGE,
                 $clean_older_than['message'],


### PR DESCRIPTION
This should prevent constrain errors, one of side effects observed is that some messages might not get deleted in the first run. #917

Usage of two additional nested subqueries is extremely heavy here though... not sure if doing one select query and then using PHP to select ids to remove wouldn't be a lighter solution here.

PS. telegram_update query was broken because of this missing `AND updated_at < \'%1$s\'` statement for `chat` table - it didn't clean the table until I added that - @noplanman ?