### PR TITLE
Helper for sending `InputMedia` objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Exclamation symbols (:exclamation:) note something of importance e.g. breaking c
 
 ## [Unreleased]
 ### Added
+- Helper for sending `InputMedia` objects using `Request::sendMediaGroup()` and `Request::editMediaMessage()` methods.
 ### Changed
 ### Deprecated
 - Botan.io service has been discontinued.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Exclamation symbols (:exclamation:) note something of importance e.g. breaking c
 - Botan.io service has been discontinued.
 ### Removed
 ### Fixed
+- Return correct objects for requests.
 ### Security
 
 ## [0.55.1] - 2019-01-06

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Exclamation symbols (:exclamation:) note something of importance e.g. breaking c
 ## [Unreleased]
 ### Added
 - Helper for sending `InputMedia` objects using `Request::sendMediaGroup()` and `Request::editMediaMessage()` methods.
+- Allow passing absolute file path for InputFile fields, instead of `Request::encodeFile($path)`.
 ### Changed
 ### Deprecated
 - Botan.io service has been discontinued.

--- a/src/Entities/Entity.php
+++ b/src/Entities/Entity.php
@@ -12,7 +12,7 @@ namespace Longman\TelegramBot\Entities;
 
 use Exception;
 use Longman\TelegramBot\Entities\InlineQuery\InlineEntity;
-use Longman\TelegramBot\TelegramLog;
+use Longman\TelegramBot\Entities\InputMedia\InputMedia;
 
 /**
  * Class Entity
@@ -149,7 +149,7 @@ abstract class Entity
             }
         } elseif ($action === 'set') {
             // Limit setters to specific classes.
-            if ($this instanceof InlineEntity || $this instanceof Keyboard || $this instanceof KeyboardButton) {
+            if ($this instanceof InlineEntity || $this instanceof InputMedia || $this instanceof Keyboard || $this instanceof KeyboardButton) {
                 $this->$property_name = $args[0];
 
                 return $this;

--- a/src/Request.php
+++ b/src/Request.php
@@ -363,6 +363,7 @@ class Request
                 // Magical media input helper.
                 $item = self::mediaInputHelper($item, $has_resource, $multipart);
             } elseif (array_key_exists(self::$current_action, self::$input_file_fields) && in_array($key, self::$input_file_fields[self::$current_action], true)) {
+                // Allow absolute paths to local files.
                 if (is_string($item) && file_exists($item)) {
                     $item = new Stream(self::encodeFile($item));
                 }
@@ -397,9 +398,17 @@ class Request
      * and
      * Request::sendMediaGroup([
      *     'media'   => [
-     *         new InputMediaPhoto(['media' => Request::encodeFile($photo_1)]),
-     *         new InputMediaPhoto(['media' => Request::encodeFile($photo_2)]),
-     *         new InputMediaVideo(['media' => Request::encodeFile($video_1)]),
+     *         new InputMediaPhoto(['media' => Request::encodeFile($local_photo_1)]),
+     *         new InputMediaPhoto(['media' => Request::encodeFile($local_photo_2)]),
+     *         new InputMediaVideo(['media' => Request::encodeFile($local_video_1)]),
+     *     ],
+     * ]);
+     * and even
+     * Request::sendMediaGroup([
+     *     'media'   => [
+     *         new InputMediaPhoto(['media' => $local_photo_1]),
+     *         new InputMediaPhoto(['media' => $local_photo_2]),
+     *         new InputMediaVideo(['media' => $local_video_1]),
      *     ],
      * ]);
      *
@@ -420,6 +429,12 @@ class Request
             }
 
             $media = $media_item->getMedia();
+
+            // Allow absolute paths to local files.
+            if (is_string($media) && file_exists($media)) {
+                $media = new Stream(self::encodeFile($media));
+            }
+
             if (is_resource($media) || $media instanceof Stream) {
                 $has_resource = true;
                 $rnd_key      = uniqid('media_', false);

--- a/src/Request.php
+++ b/src/Request.php
@@ -223,6 +223,30 @@ class Request
     ];
 
     /**
+     * Available fields for InputFile helper
+     *
+     * This is basically the list of all fields that allow InputFile objects
+     * for which input can be simplified by providing local path directly  as string.
+     *
+     * @var array
+     */
+    private static $input_file_fields = [
+        'setWebhook'          => ['certificate'],
+        'sendPhoto'           => ['photo'],
+        'sendAudio'           => ['audio', 'thumb'],
+        'sendDocument'        => ['document', 'thumb'],
+        'sendVideo'           => ['video', 'thumb'],
+        'sendAnimation'       => ['animation', 'thumb'],
+        'sendVoice'           => ['voice', 'thumb'],
+        'sendVideoNote'       => ['video_note', 'thumb'],
+        'setChatPhoto'        => ['photo'],
+        'sendSticker'         => ['sticker'],
+        'uploadStickerFile'   => ['png_sticker'],
+        'createNewStickerSet' => ['png_sticker'],
+        'addStickerToSet'     => ['png_sticker'],
+    ];
+
+    /**
      * Initialize
      *
      * @param \Longman\TelegramBot\Telegram $telegram
@@ -327,6 +351,7 @@ class Request
      * @param array $data
      *
      * @return array
+     * @throws TelegramException
      */
     private static function setUpRequestParams(array $data)
     {
@@ -337,6 +362,10 @@ class Request
             if ($key === 'media') {
                 // Magical media input helper.
                 $item = self::mediaInputHelper($item, $has_resource, $multipart);
+            } elseif (array_key_exists(self::$current_action, self::$input_file_fields) && in_array($key, self::$input_file_fields[self::$current_action], true)) {
+                if (is_string($item) && file_exists($item)) {
+                    $item = new Stream(self::encodeFile($item));
+                }
             } elseif (is_array($item)) {
                 // Convert any nested arrays into JSON strings.
                 $item = json_encode($item);

--- a/tests/unit/Entities/ServerResponseTest.php
+++ b/tests/unit/Entities/ServerResponseTest.php
@@ -25,6 +25,12 @@ use Longman\TelegramBot\Request;
  */
 class ServerResponseTest extends TestCase
 {
+    protected function setUp()
+    {
+        // Make sure the current action in the Request class is unset.
+        TestHelpers::setStaticProperty(Request::class, 'current_action', null);
+    }
+
     public function sendMessageOk()
     {
         return '{
@@ -193,6 +199,7 @@ class ServerResponseTest extends TestCase
 
     public function getUserProfilePhotos()
     {
+        TestHelpers::setStaticProperty(Request::class, 'current_action', 'getUserProfilePhotos');
         return '{
             "ok":true,
             "result":{
@@ -238,6 +245,7 @@ class ServerResponseTest extends TestCase
 
     public function getFile()
     {
+        TestHelpers::setStaticProperty(Request::class, 'current_action', 'getFile');
         return '{
             "ok":true,
             "result":{
@@ -301,6 +309,7 @@ class ServerResponseTest extends TestCase
     
     public function getStickerSet()
     {
+        TestHelpers::setStaticProperty(Request::class, 'current_action', 'getStickerSet');
         return '{
             "ok":true,
             "result":{


### PR DESCRIPTION
Neat little internal helper to simplify the passing of files to media related methods.

Basically, it automatically generated multipart fields with the attached files and links them automagically.

~~*todo*: Same procedure for `thumb` fields.~~

```php
Request::sendMediaGroup([
    'chat_id'  => $chat_id,
    'media'    => [
        new InputMediaPhoto(['media' => '/path/to/some/photo.png']), // direct path as string is now possible too!
        new InputMediaVideo(['media' => Request::encodeFile('/path/to/my/video.mp4'))]),
        new InputMediaPhoto(['media' => Request::encodeFile('/path/to/another/photo.png']),
    ],
]);
```
instead of
```php
Request::sendMediaGroup([
    'chat_id'  => $chat_id,
    'photo_1'  => Request::encodeFile('/path/to/some/photo.png'),
    'photo_2'  => Request::encodeFile('/path/to/another/photo.png'),
    'my_video' => Request::encodeFile('/path/to/my/video.mp4'),
    'media'    => [
        new InputMediaPhoto(['media' => 'attach://photo_1']),
        new InputMediaVideo(['media' => 'attach://my_video']),
        new InputMediaPhoto(['media' => 'attach://photo_2']),
    ],
]);
```

and

```php
Request::editMessageMedia([
    'chat_id'    => $chat_id,
    'message_id' => $message_id,
    'media'      => new InputMediaPhoto([
        'caption' => 'New Caption!',
        'media'   => '/path/to/some/photo.png',
    ]),
]);
```
instead of
```php
Request::editMessageMedia([
    'chat_id'    => $chat_id,
    'message_id' => $message_id,
    'photo_1'    => Request::encodeFile('/path/to/some/photo.png'),
    'media'      => new InputMediaPhoto([
        'caption' => 'New Caption!',
        'media'   => 'attach://photo_1',
    ]),
]);
```