### PR TITLE
InputMedia methods fixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Exclamation symbols (:exclamation:) note something of importance e.g. breaking c
 ### Changed
 ### Deprecated
 ### Removed
+- Abstract methods from `InputMedia` interface, as method annotations didn't work for propagation.
 ### Fixed
 ### Security
 

--- a/src/Entities/InputMedia/InputMedia.php
+++ b/src/Entities/InputMedia/InputMedia.php
@@ -4,20 +4,5 @@ namespace Longman\TelegramBot\Entities\InputMedia;
 
 interface InputMedia
 {
-    /**
-     * @return string Type of the result.
-     */
-    public function getType();
 
-    /**
-     * @return string File to send.
-     */
-    public function getMedia();
-
-    /**
-     * @param string $media File to send.
-     *
-     * @return string
-     */
-    public function setMedia($media);
 }


### PR DESCRIPTION
| ?            |  !
|---           | ---
| Type         | bug
| BC Break     | no
| Fixed issues | #934 

#### Summary

Abstract `InputMedia` methods weren't being satisfied with annotated class methods.
