### PR TITLE
Fix logging deprecation output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,11 @@ Exclamation symbols (:exclamation:) note something of importance e.g. breaking c
 - [:ledger: View file changes][Unreleased]
 ### Added
 ### Changed
+- Logging only updates or only debug/errors is now possible.
 ### Deprecated
 ### Removed
 ### Fixed
+- Don't output deprecation notices if no logging is enabled.
 ### Security
 
 ## [0.59.0] - 2019-07-07

--- a/src/TelegramLog.php
+++ b/src/TelegramLog.php
@@ -88,8 +88,8 @@ class TelegramLog
      */
     public static function initialize(LoggerInterface $logger = null, LoggerInterface $update_logger = null)
     {
-        // Clearly deprecated code still being executed.
-        if ($logger === null) {
+        if ($logger === null && $update_logger === null) {
+            // Clearly deprecated code still being executed.
             (defined('PHPUNIT_TESTSUITE') && PHPUNIT_TESTSUITE) || trigger_error('A PSR-3 compatible LoggerInterface object must be provided. Initialise with a preconfigured logger instance.', E_USER_DEPRECATED);
             $logger = new Logger('bot_log');
         } elseif ($logger instanceof Logger) {
@@ -286,11 +286,12 @@ class TelegramLog
         } elseif ($name === 'update') {
             $logger = self::$update_logger;
             $name   = 'info';
-        } else {
-            return;
         }
 
-        self::initialize(self::$logger, self::$update_logger);
+        // Clearly we have no logging enabled.
+        if ($logger === null) {
+            return;
+        }
 
         // Replace any placeholders from the passed context.
         if (count($arguments) >= 2) {


### PR DESCRIPTION
| ?            |  !
|---           | ---
| Type         | bug
| BC Break     | no
| Fixed issues | #982 

#### Summary

- Don't output deprecation error if no logging is enabled.
- Allow more logging flexibility.