### PR TITLE
Use existing HTTP client on Telegram initialisation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Exclamation symbols (:exclamation:) note something of importance e.g. breaking c
 ### Removed
 ### Fixed
 - Don't output deprecation notices if no logging is enabled.
+- Respect custom HTTP Client initialisation, no matter when it is set.
 ### Security
 
 ## [0.59.0] - 2019-07-07

--- a/src/Request.php
+++ b/src/Request.php
@@ -264,7 +264,7 @@ class Request
         }
 
         self::$telegram = $telegram;
-        self::setClient(new Client(['base_uri' => self::$api_base_uri]));
+        self::setClient(self::$client ?: new Client(['base_uri' => self::$api_base_uri]));
     }
 
     /**


### PR DESCRIPTION
| ?            |  !
|---           | ---
| Type         | bug
| BC Break     | no
| Fixed issues | #985 

#### Summary

Custom HTTP Client is used if it has already been set before Telegram initialisation.
