### PR TITLE
Non-existing commands should execute `GenericCommand`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Exclamation symbols (:exclamation:) note something of importance e.g. breaking c
 ### Deprecated
 ### Removed
 ### Fixed
+- Non-existing commands now correctly execute `GenericCommand` again.
 ### Security
 
 ## [0.59.1] - 2019-07-18

--- a/src/Telegram.php
+++ b/src/Telegram.php
@@ -468,7 +468,9 @@ class Telegram
 
             // Empty usage string denotes a non-executable command.
             // @see https://github.com/php-telegram-bot/core/issues/772#issuecomment-388616072
-            if ($command_obj !== null && $command_obj->getUsage() !== '') {
+            if (($command_obj === null && $type === 'command')
+                || ($command_obj !== null && $command_obj->getUsage() !== '')
+            ) {
                 $command = $command_tmp;
             }
         } else {


### PR DESCRIPTION
| ?            |  !
|---           | ---
| Type         | bug
| BC Break     | no

#### Summary

When a command that doesn't exist is executed, the `GenericCommand` should be executed instead, not `GenericmessageCommand`.