### PR TITLE
Save boolean value for Polls correctly in DB.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Exclamation symbols (:exclamation:) note something of importance e.g. breaking c
 ### Deprecated
 ### Removed
 ### Fixed
+- Boolean value for Polls gets saved correctly in MySQL DB.
 ### Security
 
 ## [0.60.0] - 2019-08-16

--- a/src/DB.php
+++ b/src/DB.php
@@ -845,7 +845,7 @@ class DB
             $sth->bindValue(':id', $poll->getId());
             $sth->bindValue(':question', $poll->getQuestion());
             $sth->bindValue(':options', self::entitiesArrayToJson($poll->getOptions() ?: null));
-            $sth->bindValue(':is_closed', $poll->getIsClosed());
+            $sth->bindValue(':is_closed', $poll->getIsClosed(), PDO::PARAM_INT);
             $sth->bindValue(':created_at', self::getTimestamp());
 
             return $sth->execute();


### PR DESCRIPTION
| ?            |  !
|---           | ---
| Type         | bug
| BC Break     | yes
| Fixed issues | #995

#### Summary

The boolean value for the Polls `is_closed` field now gets saved correctly.