### PR TITLE
Fix Tidelift link

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,4 +1,4 @@
-tidelift: packagist/longman%2Ftelegram-bot
+tidelift: packagist/longman/telegram-bot
 patreon: phptelegrambot
 liberapay: PHP-Telegram-Bot
 open_collective: php-telegram-bot


### PR DESCRIPTION
@noplanman I was noticing that your Tidelift marketing task wasn't being marked as complete because the value didn't match the one we were looking for. I've corrected it here, then we should be able to unlock the new enterprise language.