### PR TITLE
Return correct type for GIF message.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Exclamation symbols (:exclamation:) note something of importance e.g. breaking c
 ### Removed
 ### Fixed
 - Execution of `/start` command without any custom implementation.
+- Return `animation` type for GIF Message (which returns both `animation` and `document`).
 ### Security
 
 ## [0.61.1] - 2019-11-23

--- a/src/Entities/Animation.php
+++ b/src/Entities/Animation.php
@@ -29,5 +29,13 @@ namespace Longman\TelegramBot\Entities;
  **/
 class Animation extends Entity
 {
-
+    /**
+     * {@inheritdoc}
+     */
+    protected function subEntities()
+    {
+        return [
+            'thumb' => PhotoSize::class,
+        ];
+    }
 }

--- a/src/Entities/Message.php
+++ b/src/Entities/Message.php
@@ -206,8 +206,8 @@ class Message extends Entity
         $types = [
             'text',
             'audio',
-            'document',
             'animation',
+            'document',
             'game',
             'photo',
             'sticker',


### PR DESCRIPTION
| ?            |  !
|---           | ---
| Type         | bug
| BC Break     | no
| Fixed issues | #1042

#### Summary
Returns `animation` message type for GIF message instead of `document`.
