### PR TITLE
Feature/33 update filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Exclamation symbols (:exclamation:) note something of importance e.g. breaking c
 ### Notes
 - [:ledger: View file changes][Unreleased]
 ### Added
+- New method `setUpdateFilter($callback)` used to filter `processUpdate(Update $update)` calls. If `$callback` evaluates to false the update is not processed and a `ServerResponse()` is returned where `->isOk()` is false.
 - Replaced 'generic' and 'genericmessage' strings with Telegram::GENERIC_COMMAND and Telegram::GENERIC_MESSAGE_COMMAND constants (@1int)
 - Bot API 4.8 (Extra Poll and Dice features).
 - Allow custom MySQL port to be defined for tests.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Exclamation symbols (:exclamation:) note something of importance e.g. breaking c
 ### Notes
 - [:ledger: View file changes][Unreleased]
 ### Added
-- New method `setUpdateFilter($callback)` used to filter `processUpdate(Update $update)` calls. If `$callback` evaluates to false the update is not processed and a `ServerResponse()` is returned where `->isOk()` is false.
+- New method `setUpdateFilter($callback)` used to filter `processUpdate(Update $update)` calls. If `$callback` returns `false` the update isn't processed and an empty falsey `ServerResponse` is returned. (@VRciF)
 - Replaced 'generic' and 'genericmessage' strings with Telegram::GENERIC_COMMAND and Telegram::GENERIC_MESSAGE_COMMAND constants (@1int)
 - Bot API 4.8 (Extra Poll and Dice features).
 - Allow custom MySQL port to be defined for tests.

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ A Telegram Bot based on the official [Telegram Bot API]
     - [getUserProfilePhoto](#getuserprofilephoto)
     - [getFile and downloadFile](#getfile-and-downloadfile)
     - [Send message to all active chats](#send-message-to-all-active-chats)
+    - [Filter Update](#filter-update)
 - [Utils](#utils)
     - [MySQL storage (Recommended)](#mysql-storage-recommended)
         - [External Database connection](#external-database-connection)
@@ -413,6 +414,25 @@ $results = Request::sendToActiveChats(
 ```
 
 You can also broadcast a message to users, from the private chat with your bot. Take a look at the [admin commands](#admin-commands) below.
+
+#### Filter Update
+
+Update processing can be allowed or denied by defining a custom update filter.
+Let's say we only want to allow messages from a user with ID 428, we can do the following before handling the request:
+
+```php
+$telegram->setUpdateFilter(function (Update $update, Telegram $telegram, &$reason = 'Update denied by update_filter') {
+    $user_id = $update->getMessage()->getFrom()->getId();
+    if ($user_id === 428) {
+        return true;
+    }
+
+    $reason = "Invalid user with ID {$user_id}";
+    return false;
+});
+```
+
+The reason for denying an update can be defined with the `$reason` parameter. This text gets written to the debug log.
 
 ## Utils
 

--- a/src/Telegram.php
+++ b/src/Telegram.php
@@ -464,14 +464,15 @@ class Telegram
         $this->last_update_id = $update->getUpdateId();
 
         if (is_callable($this->update_filter)) {
+            $reason = 'Update denied by update_filter';
             try {
-                $allowed = (bool) call_user_func($this->update_filter, $update, $this);
+                $allowed = (bool) call_user_func_array($this->update_filter, [$update, $this, &$reason]);
             } catch (\Exception $e) {
                 $allowed = false;
             }
 
             if (!$allowed) {
-                TelegramLog::debug('Update denied by update_filter');
+                TelegramLog::debug($reason);
                 return new ServerResponse(['ok' => false, 'description' => 'denied'], null);
             }
         }

--- a/src/Telegram.php
+++ b/src/Telegram.php
@@ -464,15 +464,15 @@ class Telegram
         $this->last_update_id = $update->getUpdateId();
 
         $allowed = true;
-        if(is_callable($this->update_filter)){
+        if (is_callable($this->update_filter)) {
             try {
                 $allowed = (bool)call_user_func_array($this->update_filter, [$update, $this]);
-            }catch(\Exception $e){
+            } catch (\Exception $e) {
                 $allowed = false;
             }
         }
 
-        if(!$allowed){
+        if (!$allowed) {
             TelegramLog::debug('Update denied by update_filter');
             return new ServerResponse(['ok' => false, 'description' => 'denied'], null);
         }

--- a/tests/unit/TelegramTest.php
+++ b/tests/unit/TelegramTest.php
@@ -15,6 +15,7 @@ use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
 use Longman\TelegramBot\Entities\Update;
 use Longman\TelegramBot\Exception\TelegramException;
 use Longman\TelegramBot\Telegram;
+use Longman\TelegramBot\TelegramLog;
 
 /**
  * @package         TelegramTest
@@ -171,14 +172,27 @@ class TelegramTest extends TestCase
             }
         }';
 
+        $debug_log_file = '/tmp/php-telegram-bot-update-filter-debug.log';
+        TelegramLog::initialize(
+            new \Monolog\Logger('bot_log', [
+                (new \Monolog\Handler\StreamHandler($debug_log_file, \Monolog\Logger::DEBUG))->setFormatter(new \Monolog\Formatter\LineFormatter(null, null, true)),
+            ])
+        );
+
         $update = new Update(json_decode($rawUpdate, true), $this->telegram->getBotUsername());
-        $this->telegram->setUpdateFilter(function ($update, $telegramInstance) {
-            if ($update->getMessage()->getChat()->getId() == 313534466) {
+        $this->telegram->setUpdateFilter(function (Update $update, Telegram $telegram, &$reason) {
+            if ($update->getMessage()->getChat()->getId() === 313534466) {
+                $reason = 'Invalid user, update denied.';
                 return false;
             }
             return true;
         });
         $response = $this->telegram->processUpdate($update);
         $this->assertFalse($response->isOk());
+
+        // Check that the reason is written to the debug log.
+        $debug_log = file_get_contents($debug_log_file);
+        $this->assertStringContainsString('Invalid user, update denied.', $debug_log);
+        file_exists($debug_log_file) && unlink($debug_log_file);
     }
 }

--- a/tests/unit/TelegramTest.php
+++ b/tests/unit/TelegramTest.php
@@ -12,6 +12,7 @@
 namespace Longman\TelegramBot\Tests\Unit;
 
 use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
+use Longman\TelegramBot\Entities\Update;
 use Longman\TelegramBot\Exception\TelegramException;
 use Longman\TelegramBot\Telegram;
 
@@ -144,5 +145,40 @@ class TelegramTest extends TestCase
         $commands = $this->telegram->getCommandsList();
         $this->assertIsArray($commands);
         $this->assertNotCount(0, $commands);
+    }
+
+    public function testUpdateFilter()
+    {
+        $rawUpdate = '{
+            "update_id": 513400512,
+            "message": {
+                "message_id": 3,
+                "from": {
+                    "id": 313534466,
+                    "first_name": "first",
+                    "last_name": "last",
+                    "username": "username"
+                },
+                "chat": {
+                    "id": 313534466,
+                    "first_name": "first",
+                    "last_name": "last",
+                    "username": "username",
+                    "type": "private"
+                },
+                "date": 1499402829,
+                "text": "hi"
+            }
+        }';
+
+        $update = new Update(json_decode($rawUpdate, true), $this->telegram->getBotUsername());
+        $this->telegram->setUpdateFilter(function ($update, $telegramInstance) {
+            if ($update->getMessage()->getChat()->getId() == 313534466) {
+                return false;
+            }
+            return true;
+        });
+        $response = $this->telegram->processUpdate($update);
+        $this->assertFalse($response->isOk());
     }
 }


### PR DESCRIPTION
The goal of this PR is to provide a method to filter update messages using a custom callback which solves #527.

It is mentioned in https://github.com/php-telegram-bot/telegram-bot-manager/issues/33#issue-235095581 that this might be implemented in the telegram bot manager, I don't use the bot manager currently and only need the core running on my raspberry pi.

| ?            |  !
|---           | ---
| Type         | feature
| BC Break     | no
| Fixed issues | #527 

#### Summary

A new method `setUpdateFilter($callback)` is introduced.If the $callback returns false, the executed of processUpdate() ends with a ServerResponse where isOk() returns false.
The given test case demonstrates the usage.