### PR TITLE
Scrutinizer fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,13 +12,17 @@ Exclamation symbols (:exclamation:) note something of importance e.g. breaking c
 - Support `language_code` in `DB::selectChats()` for filtering the chats selection.
 ### Changed
 - Save notes an unescaped JSON, to allow easy DB reading and editing of values. (#1005)
+- `Request::setClient()` now accepts more flexible `ClientInterface`. (#1068)
 ### Deprecated
 ### Removed
+- Unnecessary `instanceof` checks for entities. (#1068)
+- Unused `Request::$input` variable. (#1068)
 ### Fixed
 - Execution of `/start` command without any custom implementation.
 - Return `animation` type for GIF Message (which returns both `animation` and `document`). (#1044)
 - Change lowercase function to `mb_strtolower` from `strtolower` because of `latin-extented` characters. (#1051)
 - Extend `Request::mediaInputHelper()` to include `thumb` parameter.
+- Various docblock annotations. (#1068)
 ### Security
 
 ## [0.61.1] - 2019-11-23

--- a/src/DB.php
+++ b/src/DB.php
@@ -20,7 +20,6 @@ use Longman\TelegramBot\Entities\Message;
 use Longman\TelegramBot\Entities\Payments\PreCheckoutQuery;
 use Longman\TelegramBot\Entities\Payments\ShippingQuery;
 use Longman\TelegramBot\Entities\Poll;
-use Longman\TelegramBot\Entities\ReplyToMessage;
 use Longman\TelegramBot\Entities\Update;
 use Longman\TelegramBot\Entities\User;
 use Longman\TelegramBot\Exception\TelegramException;
@@ -418,7 +417,7 @@ class DB
         }
 
         // Also insert the relationship to the chat into the user_chat table
-        if ($chat instanceof Chat) {
+        if ($chat) {
             try {
                 $sth = self::$pdo->prepare('
                     INSERT IGNORE INTO `' . TB_USER_CHAT . '`
@@ -597,8 +596,7 @@ class DB
             $date    = self::getTimestamp();
             $user_id = null;
 
-            $user = $inline_query->getFrom();
-            if ($user instanceof User) {
+            if ($user = $inline_query->getFrom()) {
                 $user_id = $user->getId();
                 self::insertUser($user, $date);
             }
@@ -641,8 +639,7 @@ class DB
             $date    = self::getTimestamp();
             $user_id = null;
 
-            $user = $chosen_inline_result->getFrom();
-            if ($user instanceof User) {
+            if ($user = $chosen_inline_result->getFrom()) {
                 $user_id = $user->getId();
                 self::insertUser($user, $date);
             }
@@ -685,16 +682,14 @@ class DB
             $date    = self::getTimestamp();
             $user_id = null;
 
-            $user = $callback_query->getFrom();
-            if ($user instanceof User) {
+            if ($user = $callback_query->getFrom()) {
                 $user_id = $user->getId();
                 self::insertUser($user, $date);
             }
 
-            $message    = $callback_query->getMessage();
             $chat_id    = null;
             $message_id = null;
-            if ($message instanceof Message) {
+            if ($message = $callback_query->getMessage()) {
                 $chat_id    = $message->getChat()->getId();
                 $message_id = $message->getMessageId();
 
@@ -754,8 +749,7 @@ class DB
             $date    = self::getTimestamp();
             $user_id = null;
 
-            $user = $shipping_query->getFrom();
-            if ($user instanceof User) {
+            if ($user = $shipping_query->getFrom()) {
                 $user_id = $user->getId();
                 self::insertUser($user, $date);
             }
@@ -797,8 +791,7 @@ class DB
             $date    = self::getTimestamp();
             $user_id = null;
 
-            $user = $pre_checkout_query->getFrom();
-            if ($user instanceof User) {
+            if ($user = $pre_checkout_query->getFrom()) {
                 $user_id = $user->getId();
                 self::insertUser($user, $date);
             }
@@ -876,21 +869,18 @@ class DB
         self::insertChat($chat, $date, $message->getMigrateToChatId());
 
         // Insert user and the relation with the chat
-        $user = $message->getFrom();
-        if ($user instanceof User) {
+        if ($user = $message->getFrom()) {
             self::insertUser($user, $date, $chat);
         }
 
         // Insert the forwarded message user in users table
         $forward_date = $message->getForwardDate() ? self::getTimestamp($message->getForwardDate()) : null;
 
-        $forward_from = $message->getForwardFrom();
-        if ($forward_from instanceof User) {
+        if ($forward_from = $message->getForwardFrom()) {
             self::insertUser($forward_from);
             $forward_from = $forward_from->getId();
         }
-        $forward_from_chat = $message->getForwardFromChat();
-        if ($forward_from_chat instanceof Chat) {
+        if ($forward_from_chat = $message->getForwardFromChat()) {
             self::insertChat($forward_from_chat);
             $forward_from_chat = $forward_from_chat->getId();
         }
@@ -910,7 +900,7 @@ class DB
                 }
             }
             $new_chat_members_ids = implode(',', $new_chat_members_ids);
-        } elseif ($left_chat_member instanceof User) {
+        } elseif ($left_chat_member) {
             // Insert the left chat user
             self::insertUser($left_chat_member, $date, $chat);
             $left_chat_member_id = $left_chat_member->getId();
@@ -940,15 +930,11 @@ class DB
                 )
             ');
 
-            $user_id = null;
-            if ($user instanceof User) {
-                $user_id = $user->getId();
-            }
+            $user_id = $user ? $user->getId() : null;
             $chat_id = $chat->getId();
 
-            $reply_to_message    = $message->getReplyToMessage();
             $reply_to_message_id = null;
-            if ($reply_to_message instanceof ReplyToMessage) {
+            if ($reply_to_message = $message->getReplyToMessage()) {
                 $reply_to_message_id = $reply_to_message->getMessageId();
                 // please notice that, as explained in the documentation, reply_to_message don't contain other
                 // reply_to_message field so recursion deep is 1
@@ -1038,8 +1024,7 @@ class DB
             self::insertChat($chat, $edit_date);
 
             // Insert user and the relation with the chat
-            $user = $edited_message->getFrom();
-            if ($user instanceof User) {
+            if ($user = $edited_message->getFrom()) {
                 self::insertUser($user, $edit_date, $chat);
             }
 
@@ -1050,10 +1035,7 @@ class DB
                 (:chat_id, :message_id, :user_id, :edit_date, :text, :entities, :caption)
             ');
 
-            $user_id = null;
-            if ($user instanceof User) {
-                $user_id = $user->getId();
-            }
+            $user_id = $user ? $user->getId() : null;
 
             $sth->bindValue(':chat_id', $chat->getId());
             $sth->bindValue(':message_id', $edited_message->getMessageId());

--- a/src/Entities/Chat.php
+++ b/src/Entities/Chat.php
@@ -24,7 +24,6 @@ namespace Longman\TelegramBot\Entities;
  * @method string          getUsername()                    Optional. Username, for private chats, supergroups and channels if available
  * @method string          getFirstName()                   Optional. First name of the other party in a private chat
  * @method string          getLastName()                    Optional. Last name of the other party in a private chat
- * @method bool            getAllMembersAreAdministrators() Optional. True if a group has ‘All Members Are Admins’ enabled. {@deprecated} {@see Chat::getPermissions()}
  * @method ChatPhoto       getPhoto()                       Optional. Chat photo. Returned only in getChat.
  * @method string          getDescription()                 Optional. Description, for groups, supergroups and channel chats. Returned only in getChat.
  * @method string          getInviteLink()                  Optional. Chat invite link, for groups, supergroups and channel chats. Each administrator in a chat generates their own invite links, so the bot must first generate the link using exportChatInviteLink. Returned only in getChat.
@@ -114,5 +113,18 @@ class Chat extends Entity
     public function isChannel()
     {
         return $this->getType() === 'channel';
+    }
+
+    /**
+     * Optional. True if a group has 'All Members Are Admins' enabled.
+     *
+     * @deprecated
+     * @see Chat::getPermissions()
+     *
+     * @return bool
+     */
+    public function getAllMembersAreAdministrators()
+    {
+        return $this->getProperty('all_members_are_administrators');
     }
 }

--- a/src/Entities/KeyboardButton.php
+++ b/src/Entities/KeyboardButton.php
@@ -18,6 +18,9 @@ use Longman\TelegramBot\Exception\TelegramException;
  *
  * @link https://core.telegram.org/bots/api#keyboardbutton
  *
+ * @property bool $request_contact
+ * @property bool $request_location
+ *
  * @method string getText()            Text of the button. If none of the optional fields are used, it will be sent to the bot as a message when the button is pressed
  * @method bool   getRequestContact()  Optional. If True, the user's phone number will be sent as a contact when the button is pressed. Available in private chats only
  * @method bool   getRequestLocation() Optional. If True, the user's current location will be sent when the button is pressed. Available in private chats only

--- a/src/Entities/Message.php
+++ b/src/Entities/Message.php
@@ -31,7 +31,7 @@ use Longman\TelegramBot\Entities\TelegramPassport\PassportData;
  * @method string            getForwardSignature()      Optional. For messages forwarded from channels, signature of the post author if present
  * @method string            getForwardSenderName()     Optional. Sender's name for messages forwarded from users who disallow adding a link to their account in forwarded messages
  * @method int               getForwardDate()           Optional. For forwarded messages, date the original message was sent in Unix time
- * @method Message           getReplyToMessage()        Optional. For replies, the original message. Note that the Message object in this field will not contain further reply_to_message fields even if it itself is a reply.
+ * @method ReplyToMessage    getReplyToMessage()        Optional. For replies, the original message. Note that the Message object in this field will not contain further reply_to_message fields even if it itself is a reply.
  * @method int               getEditDate()              Optional. Date the message was last edited in Unix time
  * @method string            getMediaGroupId()          Optional. The unique identifier of a media message group this message belongs to
  * @method string            getAuthorSignature()       Optional. Signature of the post author for messages in channels

--- a/src/Request.php
+++ b/src/Request.php
@@ -114,13 +114,6 @@ class Request
     private static $client;
 
     /**
-     * Input value of the request
-     *
-     * @var string
-     */
-    private static $input;
-
-    /**
      * Request limiter
      *
      * @var boolean
@@ -286,7 +279,8 @@ class Request
     public static function getInput()
     {
         // First check if a custom input has been set, else get the PHP input.
-        if (!($input = self::$telegram->getCustomInput())) {
+        $input = self::$telegram->getCustomInput();
+        if (empty($input)) {
             $input = file_get_contents('php://input');
         }
 
@@ -295,11 +289,9 @@ class Request
             throw new TelegramException('Input must be a string!');
         }
 
-        self::$input = $input;
+        TelegramLog::update($input);
 
-        TelegramLog::update(self::$input);
-
-        return self::$input;
+        return $input;
     }
 
     /**

--- a/src/Request.php
+++ b/src/Request.php
@@ -259,15 +259,9 @@ class Request
      * Initialize
      *
      * @param Telegram $telegram
-     *
-     * @throws TelegramException
      */
     public static function initialize(Telegram $telegram)
     {
-        if (!($telegram instanceof Telegram)) {
-            throw new TelegramException('Invalid Telegram pointer!');
-        }
-
         self::$telegram = $telegram;
         self::setClient(self::$client ?: new Client(['base_uri' => self::$api_base_uri]));
     }
@@ -276,15 +270,9 @@ class Request
      * Set a custom Guzzle HTTP Client object
      *
      * @param Client $client
-     *
-     * @throws TelegramException
      */
     public static function setClient(Client $client)
     {
-        if (!($client instanceof Client)) {
-            throw new TelegramException('Invalid GuzzleHttp\Client pointer!');
-        }
-
         self::$client = $client;
     }
 

--- a/src/Request.php
+++ b/src/Request.php
@@ -12,6 +12,7 @@
 namespace Longman\TelegramBot;
 
 use GuzzleHttp\Client;
+use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Psr7\Stream;
 use Longman\TelegramBot\Entities\File;
@@ -108,7 +109,7 @@ class Request
     /**
      * Guzzle Client object
      *
-     * @var Client
+     * @var ClientInterface
      */
     private static $client;
 
@@ -269,9 +270,9 @@ class Request
     /**
      * Set a custom Guzzle HTTP Client object
      *
-     * @param Client $client
+     * @param ClientInterface $client
      */
-    public static function setClient(Client $client)
+    public static function setClient(ClientInterface $client)
     {
         self::$client = $client;
     }


### PR DESCRIPTION
| ?            |  !
|---           | ---
| Type         | improvement
| BC Break     | no
| Fixed issues | n/a

#### Summary

- Remove unnecessary `entityof` checks.
- Remove unused `Request::$input` variable.
- Fixed various docblock annotations.
- Allow setting request client to be of type `ClientInterface` (instead of the concrete `Client` object)
