### PR TITLE
Use class constants instead of strings for 'generic' and 'genericmessage'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Exclamation symbols (:exclamation:) note something of importance e.g. breaking c
 ### Notes
 - [:ledger: View file changes][Unreleased]
 ### Added
+- Replaced 'generic' and 'genericmessage' strings with Telegram::GENERIC_COMMAND and Telegram::GENERIC_MESSAGE_COMMAND constants (@1int)
 ### Changed
 ### Deprecated
 ### Removed

--- a/src/Commands/SystemCommands/GenericmessageCommand.php
+++ b/src/Commands/SystemCommands/GenericmessageCommand.php
@@ -15,6 +15,7 @@ use Longman\TelegramBot\Commands\SystemCommand;
 use Longman\TelegramBot\Entities\ServerResponse;
 use Longman\TelegramBot\Exception\TelegramException;
 use Longman\TelegramBot\Request;
+use Longman\TelegramBot\Telegram;
 
 /**
  * Generic message command
@@ -24,7 +25,7 @@ class GenericmessageCommand extends SystemCommand
     /**
      * @var string
      */
-    protected $name = 'genericmessage';
+    protected $name = Telegram::GENERIC_MESSAGE_COMMAND;
 
     /**
      * @var string

--- a/src/Telegram.php
+++ b/src/Telegram.php
@@ -147,6 +147,16 @@ class Telegram
     protected $last_update_id = null;
 
     /**
+     * The command to be executed when there's a new message update and nothing more suitable is found
+     */
+    const GENERIC_MESSAGE_COMMAND = 'genericmessage';
+
+    /**
+     * The command to be executed by default (when no other relevant commands are applicable)
+     */
+    const FALLBACK_COMMAND = 'generic';
+
+    /**
      * Telegram constructor.
      *
      * @param string $api_key
@@ -455,7 +465,7 @@ class Telegram
         $this->getCommandsList();
 
         //If all else fails, it's a generic message.
-        $command = 'genericmessage';
+        $command = self::GENERIC_MESSAGE_COMMAND;
 
         $update_type = $this->update->getUpdateType();
         if ($update_type === 'message') {
@@ -506,12 +516,12 @@ class Telegram
 
         if (!$command_obj || !$command_obj->isEnabled()) {
             //Failsafe in case the Generic command can't be found
-            if ($command === 'generic') {
+            if ($command === self::FALLBACK_COMMAND) {
                 throw new TelegramException('Generic command missing!');
             }
 
             //Handle a generic command or non existing one
-            $this->last_command_response = $this->executeCommand('generic');
+            $this->last_command_response = $this->executeCommand(self::FALLBACK_COMMAND);
         } else {
             //execute() method is executed after preExecute()
             //This is to prevent executing a DB query without a valid connection

--- a/src/Telegram.php
+++ b/src/Telegram.php
@@ -154,7 +154,7 @@ class Telegram
     /**
      * The command to be executed by default (when no other relevant commands are applicable)
      */
-    const FALLBACK_COMMAND = 'generic';
+    const GENERIC_COMMAND = 'generic';
 
     /**
      * Telegram constructor.
@@ -516,12 +516,12 @@ class Telegram
 
         if (!$command_obj || !$command_obj->isEnabled()) {
             //Failsafe in case the Generic command can't be found
-            if ($command === self::FALLBACK_COMMAND) {
+            if ($command === self::GENERIC_COMMAND) {
                 throw new TelegramException('Generic command missing!');
             }
 
             //Handle a generic command or non existing one
-            $this->last_command_response = $this->executeCommand(self::FALLBACK_COMMAND);
+            $this->last_command_response = $this->executeCommand(self::GENERIC_COMMAND);
         } else {
             //execute() method is executed after preExecute()
             //This is to prevent executing a DB query without a valid connection


### PR DESCRIPTION
## Summary
This is a trivial change so I decided not to make an issue for it.

This PR replaces occurrences of 'generic' and 'genericmessage' with class constants to improve code clarity and prevent typos. Having class constants with proper comments also helps understand the expected behaviour.