### PR TITLE
Add `user_id` to the primary key of the `poll_answer` table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Exclamation symbols (:exclamation:) note something of importance e.g. breaking c
 ### Deprecated
 ### Removed
 ### Fixed
+- Primary key for `poll_answer` also requires the `user_id`.
 ### Security
 
 ## [0.62.0] - 2020-04-08

--- a/structure.sql
+++ b/structure.sql
@@ -231,7 +231,7 @@ CREATE TABLE IF NOT EXISTS `poll_answer` (
   `option_ids` text NOT NULL COMMENT '0-based identifiers of answer options, chosen by the user. May be empty if the user retracted their vote.',
   `created_at` timestamp NULL DEFAULT NULL COMMENT 'Entry date creation',
 
-  PRIMARY KEY (`poll_id`),
+  PRIMARY KEY (`poll_id`, `user_id`),
   FOREIGN KEY (`poll_id`) REFERENCES `poll` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 

--- a/utils/db-schema-update/0.62.0-unreleased.sql
+++ b/utils/db-schema-update/0.62.0-unreleased.sql
@@ -2,3 +2,5 @@ ALTER TABLE `poll` ADD COLUMN `explanation` varchar(255) DEFAULT NULL COMMENT 'T
 ALTER TABLE `poll` ADD COLUMN `explanation_entities` text DEFAULT NULL COMMENT 'Special entities like usernames, URLs, bot commands, etc. that appear in the explanation' AFTER `explanation`;
 ALTER TABLE `poll` ADD COLUMN `open_period` int UNSIGNED DEFAULT NULL COMMENT 'Amount of time in seconds the poll will be active after creation' AFTER `explanation_entities`;
 ALTER TABLE `poll` ADD COLUMN `close_date` timestamp NULL DEFAULT NULL COMMENT 'Point in time (Unix timestamp) when the poll will be automatically closed' AFTER `open_period`;
+
+ALTER TABLE `poll_answer` DROP PRIMARY KEY, ADD PRIMARY KEY (`poll_id`, `user_id`);


### PR DESCRIPTION
| ?            |  !
|---           | ---
| Type         | bug
| BC Break     | no
| Fixed issues | #1086 

#### Summary
Add the missing `user_id` field to the primary key of the `poll_answer` database table.