### PR TITLE
Allow logging request data in the debug log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Exclamation symbols (:exclamation:) note something of importance e.g. breaking c
 ### Added
 - Replaced 'generic' and 'genericmessage' strings with Telegram::GENERIC_COMMAND and Telegram::GENERIC_MESSAGE_COMMAND constants (@1int)
 - Bot API 4.8 (Extra Poll and Dice features).
+- `TelegramLog::$log_request_data` parameter to output the request data to the debug log.
 ### Changed
 ### Deprecated
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Exclamation symbols (:exclamation:) note something of importance e.g. breaking c
 ### Added
 - Replaced 'generic' and 'genericmessage' strings with Telegram::GENERIC_COMMAND and Telegram::GENERIC_MESSAGE_COMMAND constants (@1int)
 - Bot API 4.8 (Extra Poll and Dice features).
-- `TelegramLog::$log_request_data` parameter to output the request data to the debug log.
+- `TelegramLog::$always_log_request_and_response` parameter to force output of the request and response data to the debug log, also for successful requests
 ### Changed
 ### Deprecated
 ### Removed

--- a/doc/01-utils.md
+++ b/doc/01-utils.md
@@ -40,10 +40,10 @@ Telegram API changes continuously and it often happens that the database schema 
 If you store the raw data you can import all updates on the newest table schema by simply using [this script](../utils/importFromLog.php).
 Remember to always backup first!!
 
-### Request data
-If you'd like to also log the request data to your debug log, you can set the appropriate variable:
+### Always log request and response data
+If you's like to always log the request and response data to the debug log, also for successful requests, you can set the appropriate variable:
 ```php
-\Longman\TelegramBot\TelegramLog::$log_request_data = true;
+\Longman\TelegramBot\TelegramLog::$always_log_request_and_response = true;
 ```
 
 [PSR-3]: https://www.php-fig.org/psr/psr-3

--- a/doc/01-utils.md
+++ b/doc/01-utils.md
@@ -40,6 +40,11 @@ Telegram API changes continuously and it often happens that the database schema 
 If you store the raw data you can import all updates on the newest table schema by simply using [this script](../utils/importFromLog.php).
 Remember to always backup first!!
 
+### Request data
+If you'd like to also log the request data to your debug log, you can set the appropriate variable:
+```php
+\Longman\TelegramBot\TelegramLog::$log_request_data = true;
+```
 
 [PSR-3]: https://www.php-fig.org/psr/psr-3
 [PSR-3-providers]: https://packagist.org/providers/psr/log-implementation

--- a/src/Request.php
+++ b/src/Request.php
@@ -486,10 +486,6 @@ class Request
         $request_params['debug'] = TelegramLog::getDebugLogTempStream();
 
         try {
-            if (TelegramLog::$log_request_data) {
-                TelegramLog::debug('Request Data: ' . print_r($data, true));
-            }
-
             $response = self::$client->post(
                 '/bot' . self::$telegram->getApiKey() . '/' . $action,
                 $request_params
@@ -504,6 +500,9 @@ class Request
             $result = $e->getResponse() ? (string) $e->getResponse()->getBody() : '';
         } finally {
             //Logging verbose debug output
+            if (TelegramLog::$log_request_data) {
+                TelegramLog::debug('Request Data:' . PHP_EOL . print_r($data, true));
+            }
             TelegramLog::endDebugLogTempStream('Verbose HTTP Request output:' . PHP_EOL . '%s' . PHP_EOL);
         }
 

--- a/src/Request.php
+++ b/src/Request.php
@@ -486,6 +486,10 @@ class Request
         $request_params['debug'] = TelegramLog::getDebugLogTempStream();
 
         try {
+            if (TelegramLog::$log_request_data) {
+                TelegramLog::debug('Request Data: ' . print_r($data, true));
+            }
+
             $response = self::$client->post(
                 '/bot' . self::$telegram->getApiKey() . '/' . $action,
                 $request_params

--- a/src/Request.php
+++ b/src/Request.php
@@ -482,6 +482,7 @@ class Request
     public static function execute($action, array $data = [])
     {
         $result                  = null;
+        $response                = null;
         $request_params          = self::setUpRequestParams($data);
         $request_params['debug'] = TelegramLog::getDebugLogTempStream();
 
@@ -497,13 +498,15 @@ class Request
                 TelegramLog::update($result);
             }
         } catch (RequestException $e) {
-            $result = $e->getResponse() ? (string) $e->getResponse()->getBody() : '';
+            $response = null;
+            $result   = $e->getResponse() ? (string) $e->getResponse()->getBody() : '';
         } finally {
             //Logging verbose debug output
-            if (TelegramLog::$log_request_data) {
-                TelegramLog::debug('Request Data:' . PHP_EOL . print_r($data, true));
+            if (TelegramLog::$always_log_request_and_response || $response === null) {
+                TelegramLog::debug('Request data:' . PHP_EOL . print_r($data, true));
+                TelegramLog::debug('Response data:' . PHP_EOL . $result);
+                TelegramLog::endDebugLogTempStream('Verbose HTTP Request output:' . PHP_EOL . '%s' . PHP_EOL);
             }
-            TelegramLog::endDebugLogTempStream('Verbose HTTP Request output:' . PHP_EOL . '%s' . PHP_EOL);
         }
 
         return $result;

--- a/src/TelegramLog.php
+++ b/src/TelegramLog.php
@@ -44,11 +44,11 @@ class TelegramLog
     protected static $update_logger;
 
     /**
-     * Log the request data to the debug log
+     * Always log the request and response data to the debug log, also for successful requests
      *
      * @var bool
      */
-    public static $log_request_data = false;
+    public static $always_log_request_and_response = false;
 
     /**
      * Temporary stream handle for debug log

--- a/src/TelegramLog.php
+++ b/src/TelegramLog.php
@@ -44,6 +44,13 @@ class TelegramLog
     protected static $update_logger;
 
     /**
+     * Log the request data to the debug log
+     *
+     * @var bool
+     */
+    public static $log_request_data = false;
+
+    /**
      * Temporary stream handle for debug log
      *
      * @var resource|null


### PR DESCRIPTION
| ?            |  !
|---           | ---
| Type         | feature
| BC Break     | no
| Fixed issues | #1088 

#### Summary

Add a new `TelegramLog::$always_log_request_and_response` variable, to output request data to the debug log before posting the request itself to Telegram.