### PR TITLE
Allow custom MySQL port to be defined for tests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Exclamation symbols (:exclamation:) note something of importance e.g. breaking c
 ### Added
 - Replaced 'generic' and 'genericmessage' strings with Telegram::GENERIC_COMMAND and Telegram::GENERIC_MESSAGE_COMMAND constants (@1int)
 - Bot API 4.8 (Extra Poll and Dice features).
+- Allow custom MySQL port to be defined for tests.
 ### Changed
 ### Deprecated
 ### Removed

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -23,6 +23,7 @@
         <ini name="error_reporting" value="-1"/>
         <const name="PHPUNIT_TESTSUITE" value="true"/>
         <const name="PHPUNIT_DB_HOST" value="127.0.0.1"/>
+        <const name="PHPUNIT_DB_PORT" value="3306"/>
         <const name="PHPUNIT_DB_NAME" value="telegrambot"/>
         <const name="PHPUNIT_DB_USER" value="root"/>
         <const name="PHPUNIT_DB_PASS" value=""/>

--- a/tests/unit/ConversationTest.php
+++ b/tests/unit/ConversationTest.php
@@ -33,6 +33,7 @@ class ConversationTest extends TestCase
     {
         $credentials = [
             'host'     => PHPUNIT_DB_HOST,
+            'port'     => PHPUNIT_DB_PORT,
             'database' => PHPUNIT_DB_NAME,
             'user'     => PHPUNIT_DB_USER,
             'password' => PHPUNIT_DB_PASS,

--- a/tests/unit/TestHelpers.php
+++ b/tests/unit/TestHelpers.php
@@ -228,7 +228,11 @@ class TestHelpers
      */
     public static function emptyDb(array $credentials)
     {
-        $dsn     = 'mysql:host=' . $credentials['host'] . ';dbname=' . $credentials['database'];
+        $dsn = 'mysql:host=' . $credentials['host'] . ';dbname=' . $credentials['database'];
+        if (!empty($credentials['port'])) {
+            $dsn .= ';port=' . $credentials['port'];
+        }
+
         $options = [\PDO::MYSQL_ATTR_INIT_COMMAND => 'SET NAMES utf8'];
 
         $pdo = new \PDO($dsn, $credentials['user'], $credentials['password'], $options);


### PR DESCRIPTION
| ?            |  !
|---           | ---
| Type         | improvement
| BC Break     | no
| Fixed issues | -

#### Summary

Allow setting the MySQL port for the testsuite, to make local testing more flexible.