### PR TITLE
Add static method `Entity::parseMarkdownV2` to handle MarkdownV2.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ Exclamation symbols (:exclamation:) note something of importance e.g. breaking c
 - Replaced 'generic' and 'genericmessage' strings with Telegram::GENERIC_COMMAND and Telegram::GENERIC_MESSAGE_COMMAND constants (@1int)
 - Bot API 4.8 (Extra Poll and Dice features).
 - Allow custom MySQL port to be defined for tests.
+- New static method `Entity::escapeMarkdownV2` for MarkdownV2.
 ### Changed
+- [:exclamation:][unreleased-bc-static-method-entityescapemarkdown] Made `Entity::escapeMarkdown` static, to not require an `Entity` object.
 ### Deprecated
 ### Removed
 ### Fixed
@@ -435,6 +437,7 @@ Exclamation symbols (:exclamation:) note something of importance e.g. breaking c
 ### Deprecated
 - Move `hideKeyboard` to `removeKeyboard`.
 
+[unreleased-bc-static-method-entityescapemarkdown]: https://github.com/php-telegram-bot/core/wiki/Breaking-backwards-compatibility#static-method-entityescapemarkdown
 [0.62.0-sql-migration]: https://github.com/php-telegram-bot/core/tree/master/utils/db-schema-update/0.61.1-0.62.0.sql
 [0.61.0-sql-migration]: https://github.com/php-telegram-bot/core/tree/master/utils/db-schema-update/0.60.0-0.61.0.sql
 [0.61.0-bc-remove-monolog-from-core]: https://github.com/php-telegram-bot/core/wiki/Breaking-backwards-compatibility#remove-monolog-from-core

--- a/src/Entities/Entity.php
+++ b/src/Entities/Entity.php
@@ -193,13 +193,15 @@ abstract class Entity
     }
 
     /**
-     * Escape markdown special characters
+     * Escape markdown (v1) special characters
+     *
+     * @see https://core.telegram.org/bots/api#markdown-style
      *
      * @param string $string
      *
      * @return string
      */
-    public function escapeMarkdown($string)
+    public static function escapeMarkdown($string)
     {
         return str_replace(
             ['[', '`', '*', '_',],
@@ -209,10 +211,30 @@ abstract class Entity
     }
 
     /**
+     * Escape markdown (v2) special characters
+     *
+     * @see https://core.telegram.org/bots/api#markdownv2-style
+     *
+     * @param string $string
+     *
+     * @return string
+     */
+    public static function escapeMarkdownV2($string)
+    {
+        return str_replace(
+            ['_', '*', '[', ']', '(', ')', '~', '`', '>', '#', '+', '-', '=', '|', '{', '}', '.', '!'],
+            ['\_', '\*', '\[', '\]', '\(', '\)', '\~', '\`', '\>', '\#', '\+', '\-', '\=', '\|', '\{', '\}', '\.', '\!'],
+            $string
+        );
+    }
+
+    /**
      * Try to mention the user
      *
      * Mention the user with the username otherwise print first and last name
      * if the $escape_markdown argument is true special characters are escaped from the output
+     *
+     * @todo What about MarkdownV2?
      *
      * @param bool $escape_markdown
      *
@@ -239,7 +261,7 @@ abstract class Entity
         }
 
         if ($escape_markdown) {
-            $name = $this->escapeMarkdown($name);
+            $name = self::escapeMarkdown($name);
         }
 
         return ($is_username ? '@' : '') . $name;

--- a/tests/unit/Entities/EntityTest.php
+++ b/tests/unit/Entities/EntityTest.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * This file is part of the TelegramBot package.
+ *
+ * (c) Avtandil Kikabidze aka LONGMAN <akalongman@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Longman\TelegramBot\Tests\Unit;
+
+use Longman\TelegramBot\Entities\Entity;
+
+/**
+ * @link            https://github.com/php-telegram-bot/core
+ * @author          Baev Nikolay <gametester3d@gmail.com>
+ * @copyright       Avtandil Kikabidze <akalongman@gmail.com>
+ * @license         http://opensource.org/licenses/mit-license.php  The MIT License (MIT)
+ * @package         TelegramTest
+ */
+class EntityTest extends TestCase
+{
+    public function testEscapeMarkdown()
+    {
+        // Make sure all characters that need escaping are escaped.
+
+        // Markdown V1
+        self::assertEquals('\[\`\*\_', Entity::escapeMarkdown('[`*_'));
+        self::assertEquals('\*mark\*\_down\_~test~', Entity::escapeMarkdown('*mark*_down_~test~'));
+
+        // Markdown V2
+        self::assertEquals('\_\*\[\]\(\)\~\`\>\#\+\-\=\|\{\}\.\!', Entity::escapeMarkdownV2('_*[]()~`>#+-=|{}.!'));
+        self::assertEquals('\*mark\*\_down\_\~test\~', Entity::escapeMarkdownV2('*mark*_down_~test~'));
+    }
+}

--- a/tests/unit/Entities/UserTest.php
+++ b/tests/unit/Entities/UserTest.php
@@ -65,9 +65,6 @@ class UserTest extends TestCase
         $user = new User(['id' => 1, 'first_name' => 'John', 'last_name' => '`Taylor`']);
         self::assertEquals('John `Taylor`', $user->tryMention());
         self::assertEquals('John \`Taylor\`', $user->tryMention(true));
-
-        // Plain escapeMarkdown functionality.
-        self::assertEquals('a\`b\[c\*d\_e', $user->escapeMarkdown('a`b[c*d_e'));
     }
 
     public function testGetProperties()


### PR DESCRIPTION
| ?            |  !
|---           | ---
| Type         | improvement
| BC Break     | yes
| Fixed issues | #1093 

#### Summary
- Add new static method `Entity::parseMarkdownV2` to handle MarkdownV2.
- Change `Entity::parseMarkdown` method to be static, thus not requiring an explicit object.