### PR TITLE
Remove bot token from debug stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Exclamation symbols (:exclamation:) note something of importance e.g. breaking c
 - Bot API 4.8 (Extra Poll and Dice features).
 - Allow custom MySQL port to be defined for tests.
 - New static method `Entity::escapeMarkdownV2` for MarkdownV2.
+- Remove bot token from debug http logs, this can be disabled by setting `TelegramLog::$remove_bot_token` parameter to `false`
 ### Changed
 - [:exclamation:][unreleased-bc-static-method-entityescapemarkdown] Made `Entity::escapeMarkdown` static, to not require an `Entity` object.
 ### Deprecated

--- a/doc/01-utils.md
+++ b/doc/01-utils.md
@@ -40,6 +40,12 @@ Telegram API changes continuously and it often happens that the database schema 
 If you store the raw data you can import all updates on the newest table schema by simply using [this script](../utils/importFromLog.php).
 Remember to always backup first!!
 
+### Hiding API token from the log
+By default, the API token is removed from the log, to prevent any mistaken leakage when posting logs online.
+This behaviour can be changed by setting the appropriate variable:
+``php
+\Longman\TelegramBot\TelegramLog::$remove_bot_token = false;
+```
 
 [PSR-3]: https://www.php-fig.org/psr/psr-3
 [PSR-3-providers]: https://packagist.org/providers/psr/log-implementation

--- a/src/TelegramLog.php
+++ b/src/TelegramLog.php
@@ -51,6 +51,13 @@ class TelegramLog
     protected static $debug_log_temp_stream_handle;
 
     /**
+     * Remove bot token from debug stream
+     *
+     * @var bool
+     */
+    public static $remove_bot_token = true;
+
+    /**
      * Initialise logging.
      *
      * @param LoggerInterface|null $logger
@@ -85,7 +92,13 @@ class TelegramLog
     {
         if (is_resource(self::$debug_log_temp_stream_handle)) {
             rewind(self::$debug_log_temp_stream_handle);
-            self::debug(sprintf($message, stream_get_contents(self::$debug_log_temp_stream_handle)));
+            $stream_contents = stream_get_contents(self::$debug_log_temp_stream_handle);
+
+            if (self::$remove_bot_token) {
+                $stream_contents = preg_replace('/\/bot(\d+)\:[\w\-]+\//', '/botBOT_TOKEN_REMOVED/', $stream_contents);
+            }
+
+            self::debug(sprintf($message, $stream_contents));
             fclose(self::$debug_log_temp_stream_handle);
             self::$debug_log_temp_stream_handle = null;
         }


### PR DESCRIPTION
This will remove bot token from debug http log streams, specifically from the URL path, I don't think there is any other place the token shows up?

So this:
```
> POST /bot123456789:AAHc2FVEadqyhkTYcUuG1RiYR4Hfgpwc/sendMessage HTTP/1.1
```
becomes this:
```
> POST /botBOT_TOKEN_REMOVED/sendMessage HTTP/1.1
```

Can be disabled on demand with `TelegramLog::$remove_bot_token = false`.
Having it enabled as default will make it safe for the people to post these logs for troubleshooting.

Regex is literally modified one from `Telegram.php:172`.
My original idea was to cache the token in the class to not run regex for each entry but people might be running some weird setups where they handle multiple bots in single script.
