### PR TITLE
Add via_bot field for Bot API 4.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Exclamation symbols (:exclamation:) note something of importance e.g. breaking c
 - New static method `Entity::escapeMarkdownV2` for MarkdownV2.
 - Remove bot token from debug http logs, this can be disabled by setting `TelegramLog::$remove_bot_token` parameter to `false`
 - `TelegramLog::$always_log_request_and_response` parameter to force output of the request and response data to the debug log, also for successful requests
+- Bot API 4.9 (New `via_bot` field).
 ### Changed
 - [:exclamation:][unreleased-bc-static-method-entityescapemarkdown] Made `Entity::escapeMarkdown` static, to not require an `Entity` object.
 - Allow custom namespacing for commands. (@Jonybang)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 A Telegram Bot based on the official [Telegram Bot API]
 
-[![API Version](https://img.shields.io/badge/Bot%20API-4.8%20%28April%202020%29-32a2da.svg)](https://core.telegram.org/bots/api#april-24-2020)
+[![API Version](https://img.shields.io/badge/Bot%20API-4.9%20%28June%202020%29-32a2da.svg)](https://core.telegram.org/bots/api#june-4-2020)
 [![Join the bot support group on Telegram](https://img.shields.io/badge/telegram-@PHP__Telegram__Bot__Support-64659d.svg)](https://telegram.me/PHP_Telegram_Bot_Support)
 [![Donate](https://img.shields.io/badge/%F0%9F%92%99-Donate%20%2F%20Support%20Us-blue.svg)](#donate)
 
@@ -77,7 +77,7 @@ This Bot aims to provide a platform where one can simply write a bot and have in
 
 The Bot can:
 - Retrieve updates with [webhook](#webhook-installation) and [getUpdates](#getupdates-installation) methods.
-- Supports all types and methods according to Telegram Bot API 4.8 (April 2020).
+- Supports all types and methods according to Telegram Bot API 4.9 (June 2020).
 - Supports supergroups.
 - Handle commands in chat with other bots.
 - Manage Channel from the bot admin interface.

--- a/src/DB.php
+++ b/src/DB.php
@@ -955,6 +955,12 @@ class DB
             $forward_from_chat = $forward_from_chat->getId();
         }
 
+        $via_bot_id = null;
+        if ($via_bot = $message->getViaBot()) {
+            self::insertUser($via_bot);
+            $via_bot_id = $via_bot->getId();
+        }
+
         // New and left chat member
         $new_chat_members_ids = null;
         $left_chat_member_id  = null;
@@ -982,7 +988,7 @@ class DB
                 (
                     `id`, `user_id`, `chat_id`, `date`, `forward_from`, `forward_from_chat`, `forward_from_message_id`,
                     `forward_signature`, `forward_sender_name`, `forward_date`,
-                    `reply_to_chat`, `reply_to_message`, `edit_date`, `media_group_id`, `author_signature`, `text`, `entities`, `caption_entities`,
+                    `reply_to_chat`, `reply_to_message`, `via_bot`, `edit_date`, `media_group_id`, `author_signature`, `text`, `entities`, `caption_entities`,
                     `audio`, `document`, `animation`, `game`, `photo`, `sticker`, `video`, `voice`, `video_note`, `caption`, `contact`,
                     `location`, `venue`, `poll`, `dice`, `new_chat_members`, `left_chat_member`,
                     `new_chat_title`, `new_chat_photo`, `delete_chat_photo`, `group_chat_created`,
@@ -991,7 +997,7 @@ class DB
                 ) VALUES (
                     :message_id, :user_id, :chat_id, :date, :forward_from, :forward_from_chat, :forward_from_message_id,
                     :forward_signature, :forward_sender_name, :forward_date,
-                    :reply_to_chat, :reply_to_message, :edit_date, :media_group_id, :author_signature, :text, :entities, :caption_entities,
+                    :reply_to_chat, :reply_to_message, :via_bot, :edit_date, :media_group_id, :author_signature, :text, :entities, :caption_entities,
                     :audio, :document, :animation, :game, :photo, :sticker, :video, :voice, :video_note, :caption, :contact,
                     :location, :venue, :poll, :dice, :new_chat_members, :left_chat_member,
                     :new_chat_title, :new_chat_photo, :delete_chat_photo, :group_chat_created,
@@ -1029,6 +1035,7 @@ class DB
             $sth->bindValue(':reply_to_chat', $reply_to_chat_id);
             $sth->bindValue(':reply_to_message', $reply_to_message_id);
 
+            $sth->bindValue(':via_bot', $via_bot_id);
             $sth->bindValue(':edit_date', $message->getEditDate());
             $sth->bindValue(':media_group_id', $message->getMediaGroupId());
             $sth->bindValue(':author_signature', $message->getAuthorSignature());

--- a/src/Entities/Message.php
+++ b/src/Entities/Message.php
@@ -32,6 +32,7 @@ use Longman\TelegramBot\Entities\TelegramPassport\PassportData;
  * @method string            getForwardSenderName()     Optional. Sender's name for messages forwarded from users who disallow adding a link to their account in forwarded messages
  * @method int               getForwardDate()           Optional. For forwarded messages, date the original message was sent in Unix time
  * @method ReplyToMessage    getReplyToMessage()        Optional. For replies, the original message. Note that the Message object in this field will not contain further reply_to_message fields even if it itself is a reply.
+ * @method User              getViaBot()                Optional. Bot through which the message was sent
  * @method int               getEditDate()              Optional. Date the message was last edited in Unix time
  * @method string            getMediaGroupId()          Optional. The unique identifier of a media message group this message belongs to
  * @method string            getAuthorSignature()       Optional. Signature of the post author for messages in channels
@@ -82,6 +83,7 @@ class Message extends Entity
             'forward_from'       => User::class,
             'forward_from_chat'  => Chat::class,
             'reply_to_message'   => ReplyToMessage::class,
+            'via_bot'            => User::class,
             'entities'           => [MessageEntity::class],
             'caption_entities'   => [MessageEntity::class],
             'audio'              => Audio::class,

--- a/structure.sql
+++ b/structure.sql
@@ -80,6 +80,7 @@ CREATE TABLE IF NOT EXISTS `message` (
   `forward_date` timestamp NULL DEFAULT NULL COMMENT 'date the original message was sent in timestamp format',
   `reply_to_chat` bigint NULL DEFAULT NULL COMMENT 'Unique chat identifier',
   `reply_to_message` bigint UNSIGNED DEFAULT NULL COMMENT 'Message that this message is reply to',
+  `via_bot` bigint NULL DEFAULT NULL COMMENT 'Optional. Bot through which the message was sent',
   `edit_date` bigint UNSIGNED DEFAULT NULL COMMENT 'Date the message was last edited in Unix time',
   `media_group_id` TEXT COMMENT 'The unique identifier of a media message group this message belongs to',
   `author_signature` TEXT COMMENT 'Signature of the post author for messages in channels',
@@ -124,6 +125,7 @@ CREATE TABLE IF NOT EXISTS `message` (
   KEY `forward_from_chat` (`forward_from_chat`),
   KEY `reply_to_chat` (`reply_to_chat`),
   KEY `reply_to_message` (`reply_to_message`),
+  KEY `via_bot` (`via_bot`),
   KEY `left_chat_member` (`left_chat_member`),
   KEY `migrate_from_chat_id` (`migrate_from_chat_id`),
   KEY `migrate_to_chat_id` (`migrate_to_chat_id`),
@@ -133,6 +135,7 @@ CREATE TABLE IF NOT EXISTS `message` (
   FOREIGN KEY (`forward_from`) REFERENCES `user` (`id`),
   FOREIGN KEY (`forward_from_chat`) REFERENCES `chat` (`id`),
   FOREIGN KEY (`reply_to_chat`, `reply_to_message`) REFERENCES `message` (`chat_id`, `id`),
+  FOREIGN KEY (`via_bot`) REFERENCES `user` (`id`),
   FOREIGN KEY (`left_chat_member`) REFERENCES `user` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 

--- a/utils/db-schema-update/0.62.0-unreleased.sql
+++ b/utils/db-schema-update/0.62.0-unreleased.sql
@@ -6,3 +6,7 @@ ALTER TABLE `poll` ADD COLUMN `close_date` timestamp NULL DEFAULT NULL COMMENT '
 ALTER TABLE `poll_answer` DROP PRIMARY KEY, ADD PRIMARY KEY (`poll_id`, `user_id`);
 
 ALTER TABLE `message` DROP CONSTRAINT `message_ibfk_6`;
+ALTER TABLE `message`
+    ADD COLUMN `via_bot` bigint NULL DEFAULT NULL COMMENT 'Optional. Bot through which the message was sent' AFTER `reply_to_message`,
+    ADD KEY `via_bot` (`via_bot`),
+    ADD FOREIGN KEY (`via_bot`) REFERENCES `user` (`id`);


### PR DESCRIPTION
| ?            |  !
|---           | ---
| Type         | feature
| BC Break     | no
| Fixed issues | #1106 

#### Summary

Add new `via_bot` field to implement Bot API 4.9.

@php-telegram-bot/developers I've not been able to reproduce a situation that actually gives me that field in an update. Do any of you know how a message needs to be sent to have it populated?