### PR TITLE
Custom namespace fixes again...

### DIFF
--- a/src/Telegram.php
+++ b/src/Telegram.php
@@ -295,6 +295,10 @@ class Telegram
      */
     public function getCommandObject($command, $filepath = null)
     {
+        if (isset($this->commands_objects[$command])) {
+            return $this->commands_objects[$command];
+        }
+
         $which = ['System'];
         $this->isAdmin() && $which[] = 'Admin';
         $which[] = 'User';


### PR DESCRIPTION
`getCommandObject()` will now return a valid object when using custom namespace (instead of NULL because `$filepath` is not provided)

Not sure if this is secure as it skips check for admin commands access this way.

Previously: https://github.com/php-telegram-bot/core/pull/1115


