### PR TITLE
Move to PHP 7.2+, fix up all strict variable and parameter types

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,4 +1,6 @@
 build:
+  environment:
+    php: 7.4.11
   nodes:
     analysis:
       tests:
@@ -8,33 +10,7 @@ build:
 filter:
   paths:
     - src/
-  dependency_paths:
-    - lib/
-
-checks:
-  php:
-    check_method_contracts:
-      verify_interface_like_constraints: true
-      verify_documented_constraints: true
-      verify_parent_constraints: true
-    fix_doc_comments: true
-    fix_identation_4spaces: true
-    fix_line_ending: true
-    fix_linefeed: true
-    fix_php_opening_tag: true
-    fix_use_statements:
-      remove_unused: true
-      preserve_multiple: false
-      preserve_blanklines: true
-      order_alphabetically: true
-    more_specific_types_in_doc_comments: true
-    no_goto: true
-    param_doc_comment_if_not_inferrable: true
-    parameter_doc_comments: true
-    remove_extra_empty_lines: true
-    return_doc_comment_if_not_inferrable: true
-    return_doc_comments: true
-    simplify_boolean_return: true
+    - utils/
 
 tools:
   external_code_coverage:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
-language: php
-sudo: required
 dist: trusty
+language: php
 
 addons:
-  mariadb: 10.1
+  mariadb: '10.1'
 
 cache:
   directories:
@@ -23,14 +22,6 @@ matrix:
     - php: hhvm
   fast_finish: true
 
-notifications:
-  on_success: never
-  on_failure: always
-  webhooks:
-    on_success: always
-    urls:
-      secure: jW1RbSV8TXSL3qa2cNVhlxEGbImrQS5b8FO4xIe/Sg2S2zgXOxJZrui1d/gh6mM3dqjquvCdUkXOYYWL8Mrnbe07utUigwW4qxmsw2XDqobgUl9/yoqejLsUvccV2bbvxhSlVEnGkYox9yOd7pakBW0wLxG4Izw8ML3q+tJWYAypM/x3mRhXBMRuOhLm3cI9MwYogCq82FRBTvwTszuU74EHQE/LgQnlEwfOhBYa1sqD+HHG51H59+a0pBWiAgcROG/vPffNDzCfmgrcpU6Bw/eJjGJcDYNwjvBp90lYHYXofbWtwj0m6QvCuE7HFlG7UXXipEe+trViH9G7DpPwAf5nghEgJNholESq6DVhy+5fBFEiZfcpbhMJWzh807iL8r0Ekx3oUKe67wcOO55s/Hatln5DNq3vuVzfDhIjGkBE4Z44Il1M/n5zY5Rj/zMPpRFs9cI53wynKoFxI7gPNylqnkoztYsFv/yMf1W9moZvWqzQY0qeMLSUZNJ9TpxhETGkM3P12X/jSkBkmoBPEG1Rdq/H2e6T4bQ/K9I9UyBXM3bZ1ybUqqwyi7vQTm6RCVai1P4dgMZ4VyX79dhiGhtwCIIQSrYdqi7sLO0kTw05j0zvdaT2IEATgdnj+OOSxtJrp069OL7spkRg8EEyn6emawnsrNjqJUwksvuz1tY=
-
 git:
   depth: 1
 
@@ -47,7 +38,15 @@ before_script:
 script:
   - for SCHEMA_UPDATE_FILE in $(ls utils/db-schema-update); do mysql -u root -e "use telegrambot_migrations; source utils/db-schema-update/${SCHEMA_UPDATE_FILE};"; done;
   - composer check-code
-  - if [ "$TRAVIS_PHP_VERSION" == "7.3" ]; then composer test-cov; else composer test; fi
+  - if [ "$TRAVIS_PHP_VERSION" == "7.4" ]; then composer test-cov; else composer test; fi
 
 after_script:
-  - if [ "$TRAVIS_PHP_VERSION" == "7.3" ]; then composer test-cov-upload; fi
+  - if [ "$TRAVIS_PHP_VERSION" == "7.4" ]; then composer test-cov-upload; fi
+
+notifications:
+  on_success: never
+  on_failure: always
+  webhooks:
+    on_success: always
+    urls:
+      secure: jW1RbSV8TXSL3qa2cNVhlxEGbImrQS5b8FO4xIe/Sg2S2zgXOxJZrui1d/gh6mM3dqjquvCdUkXOYYWL8Mrnbe07utUigwW4qxmsw2XDqobgUl9/yoqejLsUvccV2bbvxhSlVEnGkYox9yOd7pakBW0wLxG4Izw8ML3q+tJWYAypM/x3mRhXBMRuOhLm3cI9MwYogCq82FRBTvwTszuU74EHQE/LgQnlEwfOhBYa1sqD+HHG51H59+a0pBWiAgcROG/vPffNDzCfmgrcpU6Bw/eJjGJcDYNwjvBp90lYHYXofbWtwj0m6QvCuE7HFlG7UXXipEe+trViH9G7DpPwAf5nghEgJNholESq6DVhy+5fBFEiZfcpbhMJWzh807iL8r0Ekx3oUKe67wcOO55s/Hatln5DNq3vuVzfDhIjGkBE4Z44Il1M/n5zY5Rj/zMPpRFs9cI53wynKoFxI7gPNylqnkoztYsFv/yMf1W9moZvWqzQY0qeMLSUZNJ9TpxhETGkM3P12X/jSkBkmoBPEG1Rdq/H2e6T4bQ/K9I9UyBXM3bZ1ybUqqwyi7vQTm6RCVai1P4dgMZ4VyX79dhiGhtwCIIQSrYdqi7sLO0kTw05j0zvdaT2IEATgdnj+OOSxtJrp069OL7spkRg8EEyn6emawnsrNjqJUwksvuz1tY=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,12 @@ Exclamation symbols (:exclamation:) note something of importance e.g. breaking c
 - [:ledger: View file changes][Unreleased]
 ### Added
 ### Changed
+- Upgrade code to PHP 7.2.
 ### Deprecated
 ### Removed
 ### Fixed
 ### Security
+- Minimum PHP 7.2.
 
 ## [0.64.0] - 2020-10-04
 ### Notes

--- a/composer.json
+++ b/composer.json
@@ -23,13 +23,13 @@
         }
     ],
     "require": {
-        "php": "^5.5|^7.0",
+        "php": "^7.2",
         "ext-pdo": "*",
         "ext-curl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",
         "psr/log": "^1.1",
-        "guzzlehttp/guzzle": "^6.3|^7.1"
+        "guzzlehttp/guzzle": "^6.5|^7.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5",
@@ -49,7 +49,7 @@
     },
     "scripts": {
         "check-code": [
-            "\"vendor/bin/phpcs\" -snp src/ tests/"
+            "\"vendor/bin/phpcs\""
         ],
         "test": [
             "\"vendor/bin/phpunit\""

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4a9f7690824b697014a98da282463ed7",
+    "content-hash": "b8464bb223a71a8bd11b848d955a21f1",
     "packages": [
         {
             "name": "guzzlehttp/guzzle",
@@ -2171,7 +2171,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^5.5|^7.0",
+        "php": "^7.2",
         "ext-pdo": "*",
         "ext-curl": "*",
         "ext-json": "*",

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,118 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ruleset name="pcsg-generated-ruleset">
+<ruleset>
     <description>PHP Code Sniffer</description>
 
+    <arg value="snp"/>
     <arg name="colors"/>
-    <arg name="parallel" value="8"/>
+    <arg name="extensions" value="php"/>
     <arg name="encoding" value="utf-8"/>
+    <arg name="parallel" value="8"/>
     <arg name="report-width" value="150"/>
 
+    <file>src/</file>
+    <file>tests/</file>
+    <file>utils/</file>
+
     <rule ref="PSR12"/>
-
-    <rule ref="Generic.CodeAnalysis.EmptyStatement"/>
-    <rule ref="Generic.CodeAnalysis.UselessOverridingMethod"/>
-    <rule ref="Generic.CodeAnalysis.UnusedFunctionParameter"/>
-    <rule ref="Generic.CodeAnalysis.JumbledIncrementer"/>
-    <rule ref="Generic.CodeAnalysis.UnconditionalIfStatement"/>
-    <rule ref="Generic.CodeAnalysis.UnnecessaryFinalModifier"/>
-
-    <rule ref="Generic.ControlStructures.InlineControlStructure"/>
-
-    <rule ref="Generic.Files.ByteOrderMark"/>
-    <rule ref="Generic.Files.LineEndings"/>
-
-    <rule ref="Generic.Formatting.DisallowMultipleStatements"/>
-    <rule ref="Generic.Formatting.SpaceAfterCast.NoSpace">
-        <type>warning</type>
-    </rule>
-    <rule ref="Generic.Functions.CallTimePassByReference"/>
-    <rule ref="Generic.Functions.FunctionCallArgumentSpacing"/>
-
-    <rule ref="Generic.Metrics.NestingLevel">
-        <properties>
-            <property name="nestingLevel" value="7"/>
-        </properties>
-    </rule>
-    <rule ref="Generic.Metrics.CyclomaticComplexity">
-        <properties>
-            <property name="complexity" value="20"/>
-            <property name="absoluteComplexity" value="40"/>
-        </properties>
-    </rule>
-    <rule ref="Generic.Metrics.CyclomaticComplexity.TooHigh">
-        <type>warning</type>
-    </rule>
-    <rule ref="Generic.Metrics.CyclomaticComplexity.MaxExceeded">
-        <type>warning</type>
-    </rule>
-
-    <rule ref="Generic.NamingConventions.ConstructorName"/>
-    <rule ref="Generic.NamingConventions.UpperCaseConstantName"/>
-    <rule ref="Generic.NamingConventions.CamelCapsFunctionName"/>
-
-    <rule ref="Generic.PHP.DeprecatedFunctions"/>
-    <rule ref="Generic.PHP.DisallowShortOpenTag"/>
-    <rule ref="Generic.PHP.ForbiddenFunctions"/>
-    <rule ref="Generic.PHP.LowerCaseConstant"/>
-    <rule ref="Generic.PHP.NoSilencedErrors"/>
-
-    <rule ref="Generic.Strings.UnnecessaryStringConcat"/>
-
-    <rule ref="Generic.WhiteSpace.DisallowTabIndent"/>
-    <rule ref="Generic.WhiteSpace.ScopeIndent"/>
-
-    <rule ref="Generic.Commenting.Todo.CommentFound">
-        <message>Please review this TODO comment: %s</message>
-        <type>warning</type>
-    </rule>
-    <rule ref="Generic.Commenting.Fixme.TaskFound">
-        <message>Please review this FIXME comment: %s</message>
-        <type>warning</type>
-    </rule>
-
-    <rule ref="Generic.Files.LineLength">
-        <properties>
-            <property name="lineLimit" value="120"/>
-            <property name="absoluteLineLimit" value="200"/>
-        </properties>
-    </rule>
-    <rule ref="Generic.Files.LineLength">
-        <exclude name="Generic.Files.LineLength.MaxExceeded"/>
-        <exclude name="Generic.Files.LineLength.TooLong"/>
-    </rule>
-    <!--
-    <rule ref="Generic.Files.LineLength.MaxExceeded">
-        <message>Line contains %s chars, which is longer than the max limit of %s</message>
-        <type>warning</type>
-    </rule>
-    <rule ref="Generic.Files.LineLength.TooLong">
-        <message>Line longer than %s characters; contains %s characters</message>
-        <type>warning</type>
-    </rule> -->
-    <rule ref="Generic.Classes.DuplicateClassName"/>
-
-    <rule ref="PEAR.Commenting.InlineComment"/>
-
-    <rule ref="PEAR.WhiteSpace.ObjectOperatorIndent"/>
-
-    <rule ref="MySource.PHP.EvalObjectFactory"/>
-    <rule ref="MySource.PHP.GetRequestData"/>
-    <!--
-    <rule ref="MySource.PHP.ReturnFunctionValue"/>
-    -->
-
-    <rule ref="Squiz.WhiteSpace.LogicalOperatorSpacing"/>
-    <rule ref="Squiz.WhiteSpace.SemicolonSpacing"/>
-    <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace.EmptyLines">
-        <type>warning</type>
-    </rule>
-    <rule ref="Squiz.WhiteSpace.CastSpacing"/>
-    <rule ref="Squiz.WhiteSpace.LanguageConstructSpacing"/>
-    <!--
-    <rule ref="Squiz.WhiteSpace.MemberVarSpacing"/>
-    -->
-    <rule ref="Squiz.WhiteSpace.OperatorSpacing"/>
-
-    <rule ref="Squiz.Scope.StaticThisUsage"/>
-
 </ruleset>

--- a/src/ChatAction.php
+++ b/src/ChatAction.php
@@ -16,50 +16,50 @@ class ChatAction
     /**
      * Typing chat action
      */
-    const TYPING = 'typing';
+    public const TYPING = 'typing';
 
     /**
      * Upload Photo chat action
      */
-    const UPLOAD_PHOTO = 'upload_photo';
+    public const UPLOAD_PHOTO = 'upload_photo';
 
     /**
      * Record Video chat action
      */
-    const RECORD_VIDEO = 'record_video';
+    public const RECORD_VIDEO = 'record_video';
 
     /**
      * Upload Video chat action
      */
-    const UPLOAD_VIDEO = 'upload_video';
+    public const UPLOAD_VIDEO = 'upload_video';
 
     /**
      * Record Audio chat action
      */
-    const RECORD_AUDIO = 'record_audio';
+    public const RECORD_AUDIO = 'record_audio';
 
     /**
      * Upload Audio chat action
      */
-    const UPLOAD_AUDIO = 'upload_audio';
+    public const UPLOAD_AUDIO = 'upload_audio';
 
     /**
      * Upload Document chat action
      */
-    const UPLOAD_DOCUMENT = 'upload_document';
+    public const UPLOAD_DOCUMENT = 'upload_document';
 
     /**
      * Find Location chat action
      */
-    const FIND_LOCATION = 'find_location';
+    public const FIND_LOCATION = 'find_location';
 
     /**
      * Record Video Note chat action
      */
-    const RECORD_VIDEO_NOTE = 'record_video_note';
+    public const RECORD_VIDEO_NOTE = 'record_video_note';
 
     /**
      * Upload Video note chat action
      */
-    const UPLOAD_VIDEO_NOTE = 'upload_video_note';
+    public const UPLOAD_VIDEO_NOTE = 'upload_video_note';
 }

--- a/src/Commands/AdminCommands/ChatsCommand.php
+++ b/src/Commands/AdminCommands/ChatsCommand.php
@@ -51,7 +51,7 @@ class ChatsCommand extends AdminCommand
      * @return ServerResponse
      * @throws TelegramException
      */
-    public function execute()
+    public function execute(): ServerResponse
     {
         $message = $this->getMessage();
 

--- a/src/Commands/AdminCommands/CleanupCommand.php
+++ b/src/Commands/AdminCommands/CleanupCommand.php
@@ -108,7 +108,7 @@ class CleanupCommand extends AdminCommand
      *
      * @return array
      */
-    private function getSettings($custom_time = '')
+    private function getSettings($custom_time = ''): array
     {
         $tables_to_clean      = self::$default_tables_to_clean;
         $user_tables_to_clean = $this->getConfig('tables_to_clean');
@@ -143,7 +143,7 @@ class CleanupCommand extends AdminCommand
      * @return array
      * @throws TelegramException
      */
-    private function getQueries($settings)
+    private function getQueries($settings): array
     {
         if (empty($settings) || !is_array($settings)) {
             throw new TelegramException('Settings variable is not an array or is empty!');
@@ -347,7 +347,7 @@ class CleanupCommand extends AdminCommand
      * @return ServerResponse
      * @throws TelegramException
      */
-    public function executeNoDb()
+    public function executeNoDb(): ServerResponse
     {
         return $this->replyToChat('*No database connection!*', ['parse_mode' => 'Markdown']);
     }
@@ -358,7 +358,7 @@ class CleanupCommand extends AdminCommand
      * @return ServerResponse
      * @throws TelegramException
      */
-    public function execute()
+    public function execute(): ServerResponse
     {
         $message = $this->getMessage();
         $text    = $message->getText(true);

--- a/src/Commands/AdminCommands/DebugCommand.php
+++ b/src/Commands/AdminCommands/DebugCommand.php
@@ -13,6 +13,7 @@ namespace Longman\TelegramBot\Commands\AdminCommands;
 
 use Longman\TelegramBot\Commands\AdminCommand;
 use Longman\TelegramBot\DB;
+use Longman\TelegramBot\Entities\ServerResponse;
 use Longman\TelegramBot\Exception\TelegramException;
 use Longman\TelegramBot\Request;
 
@@ -47,7 +48,7 @@ class DebugCommand extends AdminCommand
      * @return mixed
      * @throws TelegramException
      */
-    public function execute()
+    public function execute(): ServerResponse
     {
         $pdo     = DB::getPdo();
         $message = $this->getMessage();

--- a/src/Commands/AdminCommands/SendtoallCommand.php
+++ b/src/Commands/AdminCommands/SendtoallCommand.php
@@ -53,7 +53,7 @@ class SendtoallCommand extends AdminCommand
      * @return ServerResponse
      * @throws TelegramException
      */
-    public function execute()
+    public function execute(): ServerResponse
     {
         $text = $this->getMessage()->getText(true);
 

--- a/src/Commands/AdminCommands/SendtochannelCommand.php
+++ b/src/Commands/AdminCommands/SendtochannelCommand.php
@@ -14,6 +14,7 @@ namespace Longman\TelegramBot\Commands\AdminCommands;
 use Longman\TelegramBot\Commands\AdminCommand;
 use Longman\TelegramBot\Conversation;
 use Longman\TelegramBot\Entities\Chat;
+use Longman\TelegramBot\Entities\Entity;
 use Longman\TelegramBot\Entities\Keyboard;
 use Longman\TelegramBot\Entities\Message;
 use Longman\TelegramBot\Entities\ServerResponse;
@@ -331,7 +332,7 @@ class SendtochannelCommand extends AdminCommand
         if ($res->isOk()) {
             /** @var Chat $channel */
             $channel          = $res->getResult()->getChat();
-            $escaped_username = $channel->getUsername() ? $this->getMessage()->escapeMarkdown($channel->getUsername()) : '';
+            $escaped_username = $channel->getUsername() ? Entity::escapeMarkdown($channel->getUsername()) : '';
 
             $response = sprintf(
                 'Message successfully sent to *%s*%s',
@@ -339,7 +340,7 @@ class SendtochannelCommand extends AdminCommand
                 $escaped_username ? " (@{$escaped_username})" : ''
             );
         } else {
-            $escaped_username = $this->getMessage()->escapeMarkdown($channel_id);
+            $escaped_username = Entity::escapeMarkdown($channel_id);
             $response         = "Message not sent to *{$escaped_username}*" . PHP_EOL .
                                 '- Does the channel exist?' . PHP_EOL .
                                 '- Is the bot an admin of the channel?';

--- a/src/Commands/AdminCommands/SendtochannelCommand.php
+++ b/src/Commands/AdminCommands/SendtochannelCommand.php
@@ -60,7 +60,7 @@ class SendtochannelCommand extends AdminCommand
      * @return ServerResponse|mixed
      * @throws TelegramException
      */
-    public function execute()
+    public function execute(): ServerResponse
     {
         $message = $this->getMessage();
         $chat_id = $message->getChat()->getId();
@@ -281,7 +281,7 @@ class SendtochannelCommand extends AdminCommand
      * @return ServerResponse
      * @throws TelegramException
      */
-    protected function sendBack(Message $message, array $data)
+    protected function sendBack(Message $message, array $data): ServerResponse
     {
         $type = $message->getType();
         in_array($type, ['command', 'text'], true) && $type = 'message';
@@ -321,7 +321,7 @@ class SendtochannelCommand extends AdminCommand
      * @return string
      * @throws TelegramException
      */
-    protected function publish(Message $message, $channel_id, $caption = null)
+    protected function publish(Message $message, $channel_id, $caption = null): string
     {
         $res = $this->sendBack($message, [
             'chat_id' => $channel_id,
@@ -356,7 +356,7 @@ class SendtochannelCommand extends AdminCommand
      * @return mixed
      * @throws TelegramException
      */
-    public function executeNoDb()
+    public function executeNoDb(): ServerResponse
     {
         $message = $this->getMessage();
         $text    = trim($message->getText(true));

--- a/src/Commands/AdminCommands/WhoisCommand.php
+++ b/src/Commands/AdminCommands/WhoisCommand.php
@@ -58,7 +58,7 @@ class WhoisCommand extends AdminCommand
      * @return ServerResponse
      * @throws TelegramException
      */
-    public function execute()
+    public function execute(): ServerResponse
     {
         $message = $this->getMessage();
 

--- a/src/Commands/Command.php
+++ b/src/Commands/Command.php
@@ -95,14 +95,14 @@ abstract class Command
     /**
      * If this command is enabled
      *
-     * @var boolean
+     * @var bool
      */
     protected $enabled = true;
 
     /**
      * If this command needs mysql
      *
-     * @var boolean
+     * @var bool
      */
     protected $need_mysql = false;
 
@@ -123,13 +123,15 @@ abstract class Command
     /**
      * Constructor
      *
-     * @param Telegram $telegram
-     * @param Update   $update
+     * @param Telegram    $telegram
+     * @param Update|null $update
      */
-    public function __construct(Telegram $telegram, Update $update = null)
+    public function __construct(Telegram $telegram, ?Update $update = null)
     {
         $this->telegram = $telegram;
-        $this->setUpdate($update);
+        if ($update !== null) {
+            $this->setUpdate($update);
+        }
         $this->config = $telegram->getCommandConfig($this->name);
     }
 
@@ -140,11 +142,9 @@ abstract class Command
      *
      * @return Command
      */
-    public function setUpdate(Update $update = null)
+    public function setUpdate(Update $update): Command
     {
-        if ($update !== null) {
-            $this->update = $update;
-        }
+        $this->update = $update;
 
         return $this;
     }
@@ -155,7 +155,7 @@ abstract class Command
      * @return ServerResponse
      * @throws TelegramException
      */
-    public function preExecute()
+    public function preExecute(): ServerResponse
     {
         if ($this->need_mysql && !($this->telegram->isDbEnabled() && DB::isDbConnected())) {
             return $this->executeNoDb();
@@ -188,7 +188,7 @@ abstract class Command
      * @return ServerResponse
      * @throws TelegramException
      */
-    abstract public function execute();
+    abstract public function execute(): ServerResponse;
 
     /**
      * Execution if MySQL is required but not available
@@ -196,7 +196,7 @@ abstract class Command
      * @return ServerResponse
      * @throws TelegramException
      */
-    public function executeNoDb()
+    public function executeNoDb(): ServerResponse
     {
         return $this->replyToChat('Sorry no database connection, unable to execute "' . $this->name . '" command.');
     }
@@ -204,9 +204,9 @@ abstract class Command
     /**
      * Get update object
      *
-     * @return Update
+     * @return Update|null
      */
-    public function getUpdate()
+    public function getUpdate(): ?Update
     {
         return $this->update;
     }
@@ -221,7 +221,7 @@ abstract class Command
      *
      * @return Command
      */
-    public function __call($name, array $arguments)
+    public function __call(string $name, array $arguments)
     {
         if ($this->update === null) {
             return null;
@@ -232,23 +232,20 @@ abstract class Command
     /**
      * Get command config
      *
-     * Look for config $name if found return it, if not return null.
+     * Look for config $name if found return it, if not return $default.
      * If $name is not set return all set config.
      *
      * @param string|null $name
+     * @param mixed       $default
      *
-     * @return array|mixed|null
+     * @return mixed
      */
-    public function getConfig($name = null)
+    public function getConfig($name = null, $default = null)
     {
         if ($name === null) {
             return $this->config;
         }
-        if (isset($this->config[$name])) {
-            return $this->config[$name];
-        }
-
-        return null;
+        return $this->config[$name] ?? $default;
     }
 
     /**
@@ -256,7 +253,7 @@ abstract class Command
      *
      * @return Telegram
      */
-    public function getTelegram()
+    public function getTelegram(): Telegram
     {
         return $this->telegram;
     }
@@ -266,7 +263,7 @@ abstract class Command
      *
      * @return string
      */
-    public function getUsage()
+    public function getUsage(): string
     {
         return $this->usage;
     }
@@ -276,7 +273,7 @@ abstract class Command
      *
      * @return string
      */
-    public function getVersion()
+    public function getVersion(): string
     {
         return $this->version;
     }
@@ -286,7 +283,7 @@ abstract class Command
      *
      * @return string
      */
-    public function getDescription()
+    public function getDescription(): string
     {
         return $this->description;
     }
@@ -296,7 +293,7 @@ abstract class Command
      *
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
@@ -306,7 +303,7 @@ abstract class Command
      *
      * @return bool
      */
-    public function showInHelp()
+    public function showInHelp(): bool
     {
         return $this->show_in_help;
     }
@@ -316,7 +313,7 @@ abstract class Command
      *
      * @return bool
      */
-    public function isEnabled()
+    public function isEnabled(): bool
     {
         return $this->enabled;
     }
@@ -326,7 +323,7 @@ abstract class Command
      *
      * @return bool
      */
-    public function isPrivateOnly()
+    public function isPrivateOnly(): bool
     {
         return $this->private_only;
     }
@@ -336,7 +333,7 @@ abstract class Command
      *
      * @return bool
      */
-    public function isSystemCommand()
+    public function isSystemCommand(): bool
     {
         return ($this instanceof SystemCommand);
     }
@@ -346,7 +343,7 @@ abstract class Command
      *
      * @return bool
      */
-    public function isAdminCommand()
+    public function isAdminCommand(): bool
     {
         return ($this instanceof AdminCommand);
     }
@@ -356,7 +353,7 @@ abstract class Command
      *
      * @return bool
      */
-    public function isUserCommand()
+    public function isUserCommand(): bool
     {
         return ($this instanceof UserCommand);
     }
@@ -366,7 +363,7 @@ abstract class Command
      *
      * @return bool
      */
-    protected function removeNonPrivateMessage()
+    protected function removeNonPrivateMessage(): bool
     {
         $message = $this->getMessage() ?: $this->getEditedMessage();
 
@@ -396,7 +393,7 @@ abstract class Command
      * @return ServerResponse
      * @throws TelegramException
      */
-    public function replyToChat($text, array $data = [])
+    public function replyToChat(string $text, array $data = []): ServerResponse
     {
         if ($message = $this->getMessage() ?: $this->getEditedMessage() ?: $this->getChannelPost() ?: $this->getEditedChannelPost()) {
             return Request::sendMessage(array_merge([
@@ -417,7 +414,7 @@ abstract class Command
      * @return ServerResponse
      * @throws TelegramException
      */
-    public function replyToUser($text, array $data = [])
+    public function replyToUser(string $text, array $data = []): ServerResponse
     {
         if ($message = $this->getMessage() ?: $this->getEditedMessage()) {
             return Request::sendMessage(array_merge([

--- a/src/Commands/Command.php
+++ b/src/Commands/Command.php
@@ -240,7 +240,7 @@ abstract class Command
      *
      * @return mixed
      */
-    public function getConfig($name = null, $default = null)
+    public function getConfig(?string $name = null, $default = null)
     {
         if ($name === null) {
             return $this->config;

--- a/src/Commands/SystemCommand.php
+++ b/src/Commands/SystemCommand.php
@@ -38,7 +38,7 @@ abstract class SystemCommand extends Command
      *
      * @return ServerResponse
      */
-    public function execute()
+    public function execute(): ServerResponse
     {
         // System command, return empty ServerResponse by default
         return Request::emptyResponse();
@@ -51,7 +51,7 @@ abstract class SystemCommand extends Command
      * @throws TelegramException
      * @internal
      */
-    protected function executeActiveConversation()
+    protected function executeActiveConversation(): ?ServerResponse
     {
         $message = $this->getMessage();
         if ($message === null) {
@@ -82,7 +82,7 @@ abstract class SystemCommand extends Command
      * @throws TelegramException
      * @internal
      */
-    protected function executeDeprecatedSystemCommand()
+    protected function executeDeprecatedSystemCommand(): ?ServerResponse
     {
         $message = $this->getMessage();
         if ($message === null) {

--- a/src/Commands/SystemCommands/CallbackqueryCommand.php
+++ b/src/Commands/SystemCommands/CallbackqueryCommand.php
@@ -44,7 +44,7 @@ class CallbackqueryCommand extends SystemCommand
      *
      * @return ServerResponse
      */
-    public function execute()
+    public function execute(): ServerResponse
     {
         //$callback_query = $this->getCallbackQuery();
         //$user_id        = $callback_query->getFrom()->getId();
@@ -67,7 +67,7 @@ class CallbackqueryCommand extends SystemCommand
      *
      * @param $callback
      */
-    public static function addCallbackHandler($callback)
+    public static function addCallbackHandler($callback): void
     {
         self::$callbacks[] = $callback;
     }

--- a/src/Commands/SystemCommands/GenericmessageCommand.php
+++ b/src/Commands/SystemCommands/GenericmessageCommand.php
@@ -48,7 +48,7 @@ class GenericmessageCommand extends SystemCommand
      * @return ServerResponse
      * @throws TelegramException
      */
-    public function executeNoDb()
+    public function executeNoDb(): ServerResponse
     {
         // Try to execute any deprecated system commands.
         if (self::$execute_deprecated && $deprecated_system_command_response = $this->executeDeprecatedSystemCommand()) {
@@ -64,7 +64,7 @@ class GenericmessageCommand extends SystemCommand
      * @return ServerResponse
      * @throws TelegramException
      */
-    public function execute()
+    public function execute(): ServerResponse
     {
         // Try to continue any active conversation.
         if ($active_conversation_response = $this->executeActiveConversation()) {

--- a/src/Commands/SystemCommands/InlinequeryCommand.php
+++ b/src/Commands/SystemCommands/InlinequeryCommand.php
@@ -12,6 +12,7 @@
 namespace Longman\TelegramBot\Commands\SystemCommands;
 
 use Longman\TelegramBot\Commands\SystemCommand;
+use Longman\TelegramBot\Entities\ServerResponse;
 
 /**
  * Inline query command
@@ -38,7 +39,7 @@ class InlinequeryCommand extends SystemCommand
      *
      * @return mixed
      */
-    public function execute()
+    public function execute(): ServerResponse
     {
         //$inline_query = $this->getInlineQuery();
         //$user_id      = $inline_query->getFrom()->getId();

--- a/src/Commands/UserCommands/StartCommand.php
+++ b/src/Commands/UserCommands/StartCommand.php
@@ -45,7 +45,7 @@ class StartCommand extends UserCommand
      *
      * @return ServerResponse
      */
-    public function execute()
+    public function execute(): ServerResponse
     {
         //$message = $this->getMessage();
         //$chat_id = $message->getChat()->getId();

--- a/src/Conversation.php
+++ b/src/Conversation.php
@@ -64,7 +64,7 @@ class Conversation
     protected $command;
 
     /**
-     * Conversation contructor to initialize a new conversation
+     * Conversation constructor to initialize a new conversation
      *
      * @param int    $user_id
      * @param int    $chat_id
@@ -72,14 +72,14 @@ class Conversation
      *
      * @throws TelegramException
      */
-    public function __construct($user_id, $chat_id, $command = null)
+    public function __construct(int $user_id, int $chat_id, string $command = '')
     {
         $this->user_id = $user_id;
         $this->chat_id = $chat_id;
         $this->command = $command;
 
         //Try to load an existing conversation if possible
-        if (!$this->load() && $command !== null) {
+        if (!$this->load() && $command !== '') {
             //A new conversation start
             $this->start();
         }
@@ -90,7 +90,7 @@ class Conversation
      *
      * @return bool Always return true, to allow this method in an if statement.
      */
-    protected function clear()
+    protected function clear(): bool
     {
         $this->conversation    = null;
         $this->protected_notes = null;
@@ -105,7 +105,7 @@ class Conversation
      * @return bool
      * @throws TelegramException
      */
-    protected function load()
+    protected function load(): bool
     {
         //Select an active conversation
         $conversation = ConversationDB::selectConversation($this->user_id, $this->chat_id, 1);
@@ -134,9 +134,9 @@ class Conversation
      *
      * @return bool
      */
-    public function exists()
+    public function exists(): bool
     {
-        return ($this->conversation !== null);
+        return $this->conversation !== null;
     }
 
     /**
@@ -145,7 +145,7 @@ class Conversation
      * @return bool
      * @throws TelegramException
      */
-    protected function start()
+    protected function start(): bool
     {
         if (
             $this->command
@@ -170,9 +170,9 @@ class Conversation
      * @return bool
      * @throws TelegramException
      */
-    public function stop()
+    public function stop(): bool
     {
-        return ($this->updateStatus('stopped') && $this->clear());
+        return $this->updateStatus('stopped') && $this->clear();
     }
 
     /**
@@ -181,9 +181,9 @@ class Conversation
      * @return bool
      * @throws TelegramException
      */
-    public function cancel()
+    public function cancel(): bool
     {
-        return ($this->updateStatus('cancelled') && $this->clear());
+        return $this->updateStatus('cancelled') && $this->clear();
     }
 
     /**
@@ -194,7 +194,7 @@ class Conversation
      * @return bool
      * @throws TelegramException
      */
-    protected function updateStatus($status)
+    protected function updateStatus(string $status): bool
     {
         if ($this->exists()) {
             $fields = ['status' => $status];
@@ -218,7 +218,7 @@ class Conversation
      * @return bool
      * @throws TelegramException
      */
-    public function update()
+    public function update(): bool
     {
         if ($this->exists()) {
             $fields = ['notes' => json_encode($this->notes, JSON_UNESCAPED_UNICODE)];
@@ -235,9 +235,9 @@ class Conversation
     /**
      * Retrieve the command to execute from the conversation
      *
-     * @return string|null
+     * @return string
      */
-    public function getCommand()
+    public function getCommand(): string
     {
         return $this->command;
     }
@@ -247,7 +247,7 @@ class Conversation
      *
      * @return int
      */
-    public function getUserId()
+    public function getUserId(): int
     {
         return $this->user_id;
     }
@@ -257,7 +257,7 @@ class Conversation
      *
      * @return int
      */
-    public function getChatId()
+    public function getChatId(): int
     {
         return $this->chat_id;
     }

--- a/src/ConversationDB.php
+++ b/src/ConversationDB.php
@@ -30,8 +30,8 @@ class ConversationDB extends DB
     /**
      * Select a conversation from the DB
      *
-     * @param int   $user_id
-     * @param int   $chat_id
+     * @param int $user_id
+     * @param int $chat_id
      * @param int $limit
      *
      * @return array|bool
@@ -77,8 +77,8 @@ class ConversationDB extends DB
     /**
      * Insert the conversation in the database
      *
-     * @param int $user_id
-     * @param int $chat_id
+     * @param int    $user_id
+     * @param int    $chat_id
      * @param string $command
      *
      * @return bool

--- a/src/ConversationDB.php
+++ b/src/ConversationDB.php
@@ -20,7 +20,7 @@ class ConversationDB extends DB
     /**
      * Initialize conversation table
      */
-    public static function initializeConversation()
+    public static function initializeConversation(): void
     {
         if (!defined('TB_CONVERSATION')) {
             define('TB_CONVERSATION', self::$table_prefix . 'conversation');
@@ -30,14 +30,14 @@ class ConversationDB extends DB
     /**
      * Select a conversation from the DB
      *
-     * @param string   $user_id
-     * @param string   $chat_id
-     * @param int|null $limit
+     * @param int   $user_id
+     * @param int   $chat_id
+     * @param int $limit
      *
      * @return array|bool
      * @throws TelegramException
      */
-    public static function selectConversation($user_id, $chat_id, $limit = null)
+    public static function selectConversation(int $user_id, int $chat_id, $limit = 0)
     {
         if (!self::isDbConnected()) {
             return false;
@@ -52,7 +52,7 @@ class ConversationDB extends DB
                 AND `user_id` = :user_id
             ';
 
-            if ($limit !== null) {
+            if ($limit > 0) {
                 $sql .= ' LIMIT :limit';
             }
 
@@ -62,7 +62,7 @@ class ConversationDB extends DB
             $sth->bindValue(':user_id', $user_id);
             $sth->bindValue(':chat_id', $chat_id);
 
-            if ($limit !== null) {
+            if ($limit > 0) {
                 $sth->bindValue(':limit', $limit, PDO::PARAM_INT);
             }
 
@@ -77,14 +77,14 @@ class ConversationDB extends DB
     /**
      * Insert the conversation in the database
      *
-     * @param string $user_id
-     * @param string $chat_id
+     * @param int $user_id
+     * @param int $chat_id
      * @param string $command
      *
      * @return bool
      * @throws TelegramException
      */
-    public static function insertConversation($user_id, $chat_id, $command)
+    public static function insertConversation(int $user_id, int $chat_id, string $command): bool
     {
         if (!self::isDbConnected()) {
             return false;
@@ -122,7 +122,7 @@ class ConversationDB extends DB
      * @return bool
      * @throws TelegramException
      */
-    public static function updateConversation(array $fields_values, array $where_fields_values)
+    public static function updateConversation(array $fields_values, array $where_fields_values): bool
     {
         // Auto update the update_at field.
         $fields_values['updated_at'] = self::getTimestamp();

--- a/src/DB.php
+++ b/src/DB.php
@@ -174,9 +174,9 @@ class DB
     /**
      * Get the PDO object of the connected database
      *
-     * @return PDO
+     * @return PDO|null
      */
-    public static function getPdo(): PDO
+    public static function getPdo(): ?PDO
     {
         return self::$pdo;
     }
@@ -277,7 +277,7 @@ class DB
      */
     protected static function getTimestamp(?int $unixtime = null): string
     {
-        return date('Y-m-d H:i:s', $unixtime ?: time());
+        return date('Y-m-d H:i:s', $unixtime ?? time());
     }
 
     /**
@@ -307,12 +307,12 @@ class DB
     /**
      * Insert entry to telegram_update table
      *
-     * @param string      $update_id
-     * @param string|null $chat_id
-     * @param string|null $message_id
-     * @param string|null $edited_message_id
-     * @param string|null $channel_post_id
-     * @param string|null $edited_channel_post_id
+     * @param int         $update_id
+     * @param int|null    $chat_id
+     * @param int|null    $message_id
+     * @param int|null    $edited_message_id
+     * @param int|null    $channel_post_id
+     * @param int|null    $edited_channel_post_id
      * @param string|null $inline_query_id
      * @param string|null $chosen_inline_result_id
      * @param string|null $callback_query_id
@@ -325,12 +325,12 @@ class DB
      * @throws TelegramException
      */
     protected static function insertTelegramUpdate(
-        string $update_id,
-        ?string $chat_id = null,
-        ?string $message_id = null,
-        ?string $edited_message_id = null,
-        ?string $channel_post_id = null,
-        ?string $edited_channel_post_id = null,
+        int $update_id,
+        ?int $chat_id = null,
+        ?int $message_id = null,
+        ?int $edited_message_id = null,
+        ?int $channel_post_id = null,
+        ?int $edited_channel_post_id = null,
         ?string $inline_query_id = null,
         ?string $chosen_inline_result_id = null,
         ?string $callback_query_id = null,
@@ -446,14 +446,14 @@ class DB
     /**
      * Insert chat
      *
-     * @param Chat     $chat
-     * @param string   $date
-     * @param int|null $migrate_to_chat_id
+     * @param Chat        $chat
+     * @param string|null $date
+     * @param int|null    $migrate_to_chat_id
      *
      * @return bool If the insert was successful
      * @throws TelegramException
      */
-    public static function insertChat(Chat $chat, string $date = '', ?int $migrate_to_chat_id = null): ?bool
+    public static function insertChat(Chat $chat, ?string $date = null, ?int $migrate_to_chat_id = null): ?bool
     {
         if (!self::isDbConnected()) {
             return false;
@@ -538,13 +538,13 @@ class DB
             $message_id = $message->getMessageId();
         } elseif (($edited_message = $update->getEditedMessage()) && self::insertEditedMessageRequest($edited_message)) {
             $chat_id           = $edited_message->getChat()->getId();
-            $edited_message_id = self::$pdo->lastInsertId();
+            $edited_message_id = (int) self::$pdo->lastInsertId();
         } elseif (($channel_post = $update->getChannelPost()) && self::insertMessageRequest($channel_post)) {
             $chat_id         = $channel_post->getChat()->getId();
             $channel_post_id = $channel_post->getMessageId();
         } elseif (($edited_channel_post = $update->getEditedChannelPost()) && self::insertEditedMessageRequest($edited_channel_post)) {
             $chat_id                = $edited_channel_post->getChat()->getId();
-            $edited_channel_post_id = self::$pdo->lastInsertId();
+            $edited_channel_post_id = (int) self::$pdo->lastInsertId();
         } elseif (($inline_query = $update->getInlineQuery()) && self::insertInlineQueryRequest($inline_query)) {
             $inline_query_id = $inline_query->getId();
         } elseif (($chosen_inline_result = $update->getChosenInlineResult()) && self::insertChosenInlineResultRequest($chosen_inline_result)) {
@@ -588,7 +588,7 @@ class DB
      * @return bool If the insert was successful
      * @throws TelegramException
      */
-    public static function insertInlineQueryRequest(InlineQuery $inline_query): ?bool
+    public static function insertInlineQueryRequest(InlineQuery $inline_query): bool
     {
         if (!self::isDbConnected()) {
             return false;
@@ -631,7 +631,7 @@ class DB
      * @return bool If the insert was successful
      * @throws TelegramException
      */
-    public static function insertChosenInlineResultRequest(ChosenInlineResult $chosen_inline_result): ?bool
+    public static function insertChosenInlineResultRequest(ChosenInlineResult $chosen_inline_result): bool
     {
         if (!self::isDbConnected()) {
             return false;
@@ -674,7 +674,7 @@ class DB
      * @return bool If the insert was successful
      * @throws TelegramException
      */
-    public static function insertCallbackQueryRequest(CallbackQuery $callback_query): ?bool
+    public static function insertCallbackQueryRequest(CallbackQuery $callback_query): bool
     {
         if (!self::isDbConnected()) {
             return false;
@@ -741,7 +741,7 @@ class DB
      * @return bool If the insert was successful
      * @throws TelegramException
      */
-    public static function insertShippingQueryRequest(ShippingQuery $shipping_query): ?bool
+    public static function insertShippingQueryRequest(ShippingQuery $shipping_query): bool
     {
         if (!self::isDbConnected()) {
             return false;
@@ -783,7 +783,7 @@ class DB
      * @return bool If the insert was successful
      * @throws TelegramException
      */
-    public static function insertPreCheckoutQueryRequest(PreCheckoutQuery $pre_checkout_query): ?bool
+    public static function insertPreCheckoutQueryRequest(PreCheckoutQuery $pre_checkout_query): bool
     {
         if (!self::isDbConnected()) {
             return false;
@@ -828,7 +828,7 @@ class DB
      * @return bool If the insert was successful
      * @throws TelegramException
      */
-    public static function insertPollRequest(Poll $poll): ?bool
+    public static function insertPollRequest(Poll $poll): bool
     {
         if (!self::isDbConnected()) {
             return false;
@@ -883,7 +883,7 @@ class DB
      * @return bool If the insert was successful
      * @throws TelegramException
      */
-    public static function insertPollAnswerRequest(PollAnswer $poll_answer): ?bool
+    public static function insertPollAnswerRequest(PollAnswer $poll_answer): bool
     {
         if (!self::isDbConnected()) {
             return false;
@@ -926,7 +926,7 @@ class DB
      * @return bool If the insert was successful
      * @throws TelegramException
      */
-    public static function insertMessageRequest(Message $message): ?bool
+    public static function insertMessageRequest(Message $message): bool
     {
         if (!self::isDbConnected()) {
             return false;
@@ -1088,7 +1088,7 @@ class DB
      * @return bool If the insert was successful
      * @throws TelegramException
      */
-    public static function insertEditedMessageRequest(Message $edited_message): ?bool
+    public static function insertEditedMessageRequest(Message $edited_message): bool
     {
         if (!self::isDbConnected()) {
             return false;
@@ -1254,13 +1254,13 @@ class DB
      * @param int|null    $chat_id
      * @param string|null $inline_message_id
      *
-     * @return array Array containing TOTAL and CURRENT fields or false on invalid arguments
+     * @return array|bool Array containing TOTAL and CURRENT fields or false on invalid arguments
      * @throws TelegramException
      */
-    public static function getTelegramRequestCount(int $chat_id = null, string $inline_message_id = null): ?array
+    public static function getTelegramRequestCount(int $chat_id = null, string $inline_message_id = null)
     {
         if (!self::isDbConnected()) {
-            return [];
+            return false;
         }
 
         try {
@@ -1297,7 +1297,7 @@ class DB
      * @return bool If the insert was successful
      * @throws TelegramException
      */
-    public static function insertTelegramRequest(string $method, array $data): ?bool
+    public static function insertTelegramRequest(string $method, array $data): bool
     {
         if (!self::isDbConnected()) {
             return false;
@@ -1334,7 +1334,7 @@ class DB
      * @return bool
      * @throws TelegramException
      */
-    public static function update(string $table, array $fields_values, array $where_fields_values): ?bool
+    public static function update(string $table, array $fields_values, array $where_fields_values): bool
     {
         if (empty($fields_values) || !self::isDbConnected()) {
             return false;

--- a/src/Entities/Animation.php
+++ b/src/Entities/Animation.php
@@ -33,7 +33,7 @@ class Animation extends Entity
     /**
      * {@inheritdoc}
      */
-    protected function subEntities()
+    protected function subEntities(): array
     {
         return [
             'thumb' => PhotoSize::class,

--- a/src/Entities/Audio.php
+++ b/src/Entities/Audio.php
@@ -30,7 +30,7 @@ class Audio extends Entity
     /**
      * {@inheritdoc}
      */
-    protected function subEntities()
+    protected function subEntities(): array
     {
         return [
             'thumb' => PhotoSize::class,

--- a/src/Entities/CallbackQuery.php
+++ b/src/Entities/CallbackQuery.php
@@ -31,7 +31,7 @@ class CallbackQuery extends Entity
     /**
      * {@inheritdoc}
      */
-    protected function subEntities()
+    protected function subEntities(): array
     {
         return [
             'from'    => User::class,
@@ -46,7 +46,7 @@ class CallbackQuery extends Entity
      *
      * @return ServerResponse
      */
-    public function answer(array $data = [])
+    public function answer(array $data = []): ServerResponse
     {
         return Request::answerCallbackQuery(array_merge([
             'callback_query_id' => $this->getId(),

--- a/src/Entities/Chat.php
+++ b/src/Entities/Chat.php
@@ -38,7 +38,7 @@ class Chat extends Entity
     /**
      * {@inheritdoc}
      */
-    protected function subEntities()
+    protected function subEntities(): array
     {
         return [
             'photo'          => ChatPhoto::class,
@@ -64,9 +64,9 @@ class Chat extends Entity
      *
      * @param bool $escape_markdown
      *
-     * @return string|null
+     * @return string
      */
-    public function tryMention($escape_markdown = false)
+    public function tryMention($escape_markdown = false): string
     {
         if ($this->isPrivateChat()) {
             return parent::tryMention($escape_markdown);
@@ -80,7 +80,7 @@ class Chat extends Entity
      *
      * @return bool
      */
-    public function isGroupChat()
+    public function isGroupChat(): bool
     {
         return $this->getType() === 'group' || $this->getId() < 0;
     }
@@ -90,7 +90,7 @@ class Chat extends Entity
      *
      * @return bool
      */
-    public function isPrivateChat()
+    public function isPrivateChat(): bool
     {
         return $this->getType() === 'private';
     }
@@ -100,7 +100,7 @@ class Chat extends Entity
      *
      * @return bool
      */
-    public function isSuperGroup()
+    public function isSuperGroup(): bool
     {
         return $this->getType() === 'supergroup';
     }
@@ -110,7 +110,7 @@ class Chat extends Entity
      *
      * @return bool
      */
-    public function isChannel()
+    public function isChannel(): bool
     {
         return $this->getType() === 'channel';
     }
@@ -121,9 +121,9 @@ class Chat extends Entity
      * @deprecated
      * @see Chat::getPermissions()
      *
-     * @return bool
+     * @return bool|null
      */
-    public function getAllMembersAreAdministrators()
+    public function getAllMembersAreAdministrators(): ?bool
     {
         return $this->getProperty('all_members_are_administrators');
     }

--- a/src/Entities/ChatMember.php
+++ b/src/Entities/ChatMember.php
@@ -41,7 +41,7 @@ class ChatMember extends Entity
     /**
      * {@inheritdoc}
      */
-    protected function subEntities()
+    protected function subEntities(): array
     {
         return [
             'user' => User::class,

--- a/src/Entities/ChosenInlineResult.php
+++ b/src/Entities/ChosenInlineResult.php
@@ -27,7 +27,7 @@ class ChosenInlineResult extends Entity
     /**
      * {@inheritdoc}
      */
-    protected function subEntities()
+    protected function subEntities(): array
     {
         return [
             'from'     => User::class,

--- a/src/Entities/Document.php
+++ b/src/Entities/Document.php
@@ -28,7 +28,7 @@ class Document extends Entity
     /**
      * {@inheritdoc}
      */
-    protected function subEntities()
+    protected function subEntities(): array
     {
         return [
             'thumb' => PhotoSize::class,

--- a/src/Entities/Entity.php
+++ b/src/Entities/Entity.php
@@ -35,7 +35,7 @@ abstract class Entity
      * @param array  $data
      * @param string $bot_username
      */
-    public function __construct($data, $bot_username = '')
+    public function __construct(array $data, string $bot_username = '')
     {
         //Make sure we're not raw_data inception-ing
         if (array_key_exists('raw_data', $data)) {
@@ -56,7 +56,7 @@ abstract class Entity
      *
      * @return string
      */
-    public function toJson()
+    public function toJson(): string
     {
         return json_encode($this->getRawData());
     }
@@ -76,7 +76,7 @@ abstract class Entity
      *
      * @param array $data
      */
-    protected function assignMemberVariables(array $data)
+    protected function assignMemberVariables(array $data): void
     {
         foreach ($data as $key => $value) {
             $this->$key = $value;
@@ -88,7 +88,7 @@ abstract class Entity
      *
      * @return array
      */
-    protected function subEntities()
+    protected function subEntities(): array
     {
         return [];
     }
@@ -96,7 +96,7 @@ abstract class Entity
     /**
      * Perform any special entity validation
      */
-    protected function validate()
+    protected function validate(): void
     {
     }
 
@@ -110,11 +110,7 @@ abstract class Entity
      */
     public function getProperty($property, $default = null)
     {
-        if (isset($this->$property)) {
-            return $this->$property;
-        }
-
-        return $default;
+        return $this->$property ?? $default;
     }
 
     /**
@@ -173,7 +169,7 @@ abstract class Entity
      *
      * @return array
      */
-    protected function makePrettyObjectArray($class, $property)
+    protected function makePrettyObjectArray(string $class, string $property): array
     {
         $new_objects = [];
 
@@ -201,7 +197,7 @@ abstract class Entity
      *
      * @return string
      */
-    public static function escapeMarkdown($string)
+    public static function escapeMarkdown(string $string): string
     {
         return str_replace(
             ['[', '`', '*', '_',],
@@ -219,7 +215,7 @@ abstract class Entity
      *
      * @return string
      */
-    public static function escapeMarkdownV2($string)
+    public static function escapeMarkdownV2(string $string): string
     {
         return str_replace(
             ['_', '*', '[', ']', '(', ')', '~', '`', '>', '#', '+', '-', '=', '|', '{', '}', '.', '!'],
@@ -238,13 +234,13 @@ abstract class Entity
      *
      * @param bool $escape_markdown
      *
-     * @return string|null
+     * @return string
      */
-    public function tryMention($escape_markdown = false)
+    public function tryMention($escape_markdown = false): string
     {
-        //TryMention only makes sense for the User and Chat entity.
+        // TryMention only makes sense for the User and Chat entity.
         if (!($this instanceof User || $this instanceof Chat)) {
-            return null;
+            return '';
         }
 
         //Try with the username first...

--- a/src/Entities/Entity.php
+++ b/src/Entities/Entity.php
@@ -103,12 +103,12 @@ abstract class Entity
     /**
      * Get a property from the current Entity
      *
-     * @param mixed $property
-     * @param mixed $default
+     * @param string $property
+     * @param mixed  $default
      *
      * @return mixed
      */
-    public function getProperty($property, $default = null)
+    public function getProperty(string $property, $default = null)
     {
         return $this->$property ?? $default;
     }

--- a/src/Entities/Games/Game.php
+++ b/src/Entities/Games/Game.php
@@ -35,7 +35,7 @@ class Game extends Entity
     /**
      * {@inheritdoc}
      */
-    protected function subEntities()
+    protected function subEntities(): array
     {
         return [
             'photo'         => [PhotoSize::class],

--- a/src/Entities/Games/GameHighScore.php
+++ b/src/Entities/Games/GameHighScore.php
@@ -30,7 +30,7 @@ class GameHighScore extends Entity
     /**
      * {@inheritdoc}
      */
-    protected function subEntities()
+    protected function subEntities(): array
     {
         return [
             'user' => User::class,

--- a/src/Entities/InlineKeyboardButton.php
+++ b/src/Entities/InlineKeyboardButton.php
@@ -46,24 +46,23 @@ class InlineKeyboardButton extends KeyboardButton
      *
      * @return bool
      */
-    public static function couldBe($data)
+    public static function couldBe(array $data): bool
     {
-        return is_array($data) &&
-               array_key_exists('text', $data) && (
-                   array_key_exists('url', $data) ||
-                   array_key_exists('login_url', $data) ||
-                   array_key_exists('callback_data', $data) ||
-                   array_key_exists('switch_inline_query', $data) ||
-                   array_key_exists('switch_inline_query_current_chat', $data) ||
-                   array_key_exists('callback_game', $data) ||
-                   array_key_exists('pay', $data)
-               );
+        return array_key_exists('text', $data) && (
+                array_key_exists('url', $data) ||
+                array_key_exists('login_url', $data) ||
+                array_key_exists('callback_data', $data) ||
+                array_key_exists('switch_inline_query', $data) ||
+                array_key_exists('switch_inline_query_current_chat', $data) ||
+                array_key_exists('callback_game', $data) ||
+                array_key_exists('pay', $data)
+            );
     }
 
     /**
      * {@inheritdoc}
      */
-    protected function validate()
+    protected function validate(): void
     {
         if ($this->getProperty('text', '') === '') {
             throw new TelegramException('You must add some text to the button!');

--- a/src/Entities/InlineQuery.php
+++ b/src/Entities/InlineQuery.php
@@ -30,7 +30,7 @@ class InlineQuery extends Entity
     /**
      * {@inheritdoc}
      */
-    protected function subEntities()
+    protected function subEntities(): array
     {
         return [
             'from'     => User::class,
@@ -46,7 +46,7 @@ class InlineQuery extends Entity
      *
      * @return ServerResponse
      */
-    public function answer(array $results, array $data = [])
+    public function answer(array $results, array $data = []): ServerResponse
     {
         return Request::answerInlineQuery(array_merge([
             'inline_query_id' => $this->getId(),

--- a/src/Entities/Keyboard.php
+++ b/src/Entities/Keyboard.php
@@ -115,9 +115,9 @@ class Keyboard extends Entity
     /**
      * Create a new row in keyboard and add buttons.
      *
-     * @return $this
+     * @return Keyboard
      */
-    public function addRow(): self
+    public function addRow(): Keyboard
     {
         if (($new_row = $this->parseRow(func_get_args())) !== null) {
             $this->{$this->getKeyboardType()}[] = $new_row;

--- a/src/Entities/Keyboard.php
+++ b/src/Entities/Keyboard.php
@@ -30,12 +30,9 @@ use Longman\TelegramBot\Exception\TelegramException;
  */
 class Keyboard extends Entity
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function __construct($data = [])
+    public function __construct()
     {
-        $data = call_user_func_array([$this, 'createFromParams'], func_get_args());
+        $data = $this->createFromParams(...func_get_args());
         parent::__construct($data);
 
         // Remove any empty buttons.
@@ -47,7 +44,7 @@ class Keyboard extends Entity
      *
      * @return bool
      */
-    public function isInlineKeyboard()
+    public function isInlineKeyboard(): bool
     {
         return $this instanceof InlineKeyboard;
     }
@@ -57,7 +54,7 @@ class Keyboard extends Entity
      *
      * @return string
      */
-    public function getKeyboardButtonClass()
+    public function getKeyboardButtonClass(): string
     {
         return $this->isInlineKeyboard() ? InlineKeyboardButton::class : KeyboardButton::class;
     }
@@ -67,7 +64,7 @@ class Keyboard extends Entity
      *
      * @return string
      */
-    public function getKeyboardType()
+    public function getKeyboardType(): string
     {
         return $this->isInlineKeyboard() ? 'inline_keyboard' : 'keyboard';
     }
@@ -77,7 +74,7 @@ class Keyboard extends Entity
      *
      * @return array
      */
-    protected function createFromParams()
+    protected function createFromParams(): array
     {
         $keyboard_type = $this->getKeyboardType();
 
@@ -120,7 +117,7 @@ class Keyboard extends Entity
      *
      * @return $this
      */
-    public function addRow()
+    public function addRow(): self
     {
         if (($new_row = $this->parseRow(func_get_args())) !== null) {
             $this->{$this->getKeyboardType()}[] = $new_row;
@@ -132,11 +129,11 @@ class Keyboard extends Entity
     /**
      * Parse a given row to the correct array format.
      *
-     * @param array $row
+     * @param array|string $row
      *
-     * @return array
+     * @return array|null
      */
-    protected function parseRow($row)
+    protected function parseRow($row): ?array
     {
         if (!is_array($row)) {
             return null;
@@ -159,7 +156,7 @@ class Keyboard extends Entity
      *
      * @return KeyboardButton|null
      */
-    protected function parseButton($button)
+    protected function parseButton($button): ?KeyboardButton
     {
         $button_class = $this->getKeyboardButtonClass();
 
@@ -177,7 +174,7 @@ class Keyboard extends Entity
     /**
      * {@inheritdoc}
      */
-    protected function validate()
+    protected function validate(): void
     {
         $keyboard_type = $this->getKeyboardType();
         $keyboard      = $this->getProperty($keyboard_type);
@@ -204,7 +201,7 @@ class Keyboard extends Entity
      *
      * @return Keyboard
      */
-    public static function remove(array $data = [])
+    public static function remove(array $data = []): Keyboard
     {
         return new static(array_merge(['keyboard' => [], 'remove_keyboard' => true, 'selective' => false], $data));
     }
@@ -218,7 +215,7 @@ class Keyboard extends Entity
      *
      * @return Keyboard
      */
-    public static function forceReply(array $data = [])
+    public static function forceReply(array $data = []): Keyboard
     {
         return new static(array_merge(['keyboard' => [], 'force_reply' => true, 'selective' => false], $data));
     }

--- a/src/Entities/KeyboardButton.php
+++ b/src/Entities/KeyboardButton.php
@@ -37,7 +37,7 @@ use Longman\TelegramBot\Exception\TelegramException;
 class KeyboardButton extends Entity
 {
     /**
-     * {@inheritdoc}
+     * @param array|string $data
      */
     public function __construct($data)
     {
@@ -54,15 +54,15 @@ class KeyboardButton extends Entity
      *
      * @return bool
      */
-    public static function couldBe($data)
+    public static function couldBe(array $data): bool
     {
-        return is_array($data) && array_key_exists('text', $data);
+        return array_key_exists('text', $data);
     }
 
     /**
      * {@inheritdoc}
      */
-    protected function validate()
+    protected function validate(): void
     {
         if ($this->getProperty('text', '') === '') {
             throw new TelegramException('You must add some text to the button!');

--- a/src/Entities/Message.php
+++ b/src/Entities/Message.php
@@ -75,7 +75,7 @@ class Message extends Entity
     /**
      * {@inheritdoc}
      */
-    protected function subEntities()
+    protected function subEntities(): array
     {
         return [
             'from'               => User::class,
@@ -116,7 +116,7 @@ class Message extends Entity
      *
      * @return string|null
      */
-    public function getFullCommand()
+    public function getFullCommand(): ?string
     {
         $text = $this->getProperty('text');
         if (strpos($text, '/') !== 0) {
@@ -135,7 +135,7 @@ class Message extends Entity
      *
      * @return string|null
      */
-    public function getCommand()
+    public function getCommand(): ?string
     {
         if ($command = $this->getProperty('command')) {
             return $command;
@@ -167,9 +167,9 @@ class Message extends Entity
      *
      * @param bool $without_cmd
      *
-     * @return string
+     * @return string|null
      */
-    public function getText($without_cmd = false)
+    public function getText($without_cmd = false): ?string
     {
         $text = $this->getProperty('text');
 
@@ -189,7 +189,7 @@ class Message extends Entity
      *
      * @return bool
      */
-    public function botAddedInChat()
+    public function botAddedInChat(): bool
     {
         foreach ($this->getNewChatMembers() as $member) {
             if ($member instanceof User && $member->getUsername() === $this->getBotUsername()) {
@@ -205,7 +205,7 @@ class Message extends Entity
      *
      * @return string
      */
-    public function getType()
+    public function getType(): string
     {
         $types = [
             'text',

--- a/src/Entities/MessageEntity.php
+++ b/src/Entities/MessageEntity.php
@@ -28,7 +28,7 @@ class MessageEntity extends Entity
     /**
      * {@inheritdoc}
      */
-    protected function subEntities()
+    protected function subEntities(): array
     {
         return [
             'user' => User::class,

--- a/src/Entities/Payments/OrderInfo.php
+++ b/src/Entities/Payments/OrderInfo.php
@@ -30,7 +30,7 @@ class OrderInfo extends Entity
     /**
      * {@inheritdoc}
      */
-    protected function subEntities()
+    protected function subEntities(): array
     {
         return [
             'shipping_address' => ShippingAddress::class,

--- a/src/Entities/Payments/PreCheckoutQuery.php
+++ b/src/Entities/Payments/PreCheckoutQuery.php
@@ -36,7 +36,7 @@ class PreCheckoutQuery extends Entity
     /**
      * {@inheritdoc}
      */
-    protected function subEntities()
+    protected function subEntities(): array
     {
         return [
             'from'       => User::class,
@@ -52,7 +52,7 @@ class PreCheckoutQuery extends Entity
      *
      * @return ServerResponse
      */
-    public function answer($ok, array $data = [])
+    public function answer(bool $ok, array $data = []): ServerResponse
     {
         return Request::answerPreCheckoutQuery(array_merge([
             'pre_checkout_query_id' => $this->getId(),

--- a/src/Entities/Payments/ShippingOption.php
+++ b/src/Entities/Payments/ShippingOption.php
@@ -29,7 +29,7 @@ class ShippingOption extends Entity
     /**
      * {@inheritdoc}
      */
-    protected function subEntities()
+    protected function subEntities(): array
     {
         return [
             'prices' => [LabeledPrice::class],

--- a/src/Entities/Payments/ShippingQuery.php
+++ b/src/Entities/Payments/ShippingQuery.php
@@ -33,7 +33,7 @@ class ShippingQuery extends Entity
     /**
      * {@inheritdoc}
      */
-    protected function subEntities()
+    protected function subEntities(): array
     {
         return [
             'from'             => User::class,
@@ -49,7 +49,7 @@ class ShippingQuery extends Entity
      *
      * @return ServerResponse
      */
-    public function answer($ok, array $data = [])
+    public function answer(bool $ok, array $data = []): ServerResponse
     {
         return Request::answerShippingQuery(array_merge([
             'shipping_query_id' => $this->getId(),

--- a/src/Entities/Payments/SuccessfulPayment.php
+++ b/src/Entities/Payments/SuccessfulPayment.php
@@ -33,7 +33,7 @@ class SuccessfulPayment extends Entity
     /**
      * {@inheritdoc}
      */
-    protected function subEntities()
+    protected function subEntities(): array
     {
         return [
             'order_info' => OrderInfo::class,

--- a/src/Entities/Poll.php
+++ b/src/Entities/Poll.php
@@ -37,7 +37,7 @@ class Poll extends Entity
     /**
      * {@inheritdoc}
      */
-    protected function subEntities()
+    protected function subEntities(): array
     {
         return [
             'options'              => [PollOption::class],

--- a/src/Entities/PollAnswer.php
+++ b/src/Entities/PollAnswer.php
@@ -27,7 +27,7 @@ class PollAnswer extends Entity
     /**
      * {@inheritdoc}
      */
-    protected function subEntities()
+    protected function subEntities(): array
     {
         return [
             'user' => User::class,

--- a/src/Entities/ReplyToMessage.php
+++ b/src/Entities/ReplyToMessage.php
@@ -24,7 +24,7 @@ class ReplyToMessage extends Message
      * @param array  $data
      * @param string $bot_username
      */
-    public function __construct(array $data, $bot_username = '')
+    public function __construct(array $data, string $bot_username = '')
     {
         //As explained in the documentation
         //Reply to message can't contain other reply to message entities

--- a/src/Entities/ServerResponse.php
+++ b/src/Entities/ServerResponse.php
@@ -32,14 +32,14 @@ class ServerResponse extends Entity
      * @param array  $data
      * @param string $bot_username
      */
-    public function __construct(array $data, $bot_username)
+    public function __construct(array $data, string $bot_username = '')
     {
         // Make sure we don't double-save the raw_data
         unset($data['raw_data']);
         $data['raw_data'] = $data;
 
-        $is_ok  = isset($data['ok']) ? (bool) $data['ok'] : false;
-        $result = isset($data['result']) ? $data['result'] : null;
+        $is_ok  = (bool) ($data['ok'] ?? false);
+        $result = $data['result'] ?? null;
 
         if ($is_ok && is_array($result)) {
             if ($this->isAssoc($result)) {
@@ -61,7 +61,7 @@ class ServerResponse extends Entity
      *
      * @return bool
      */
-    protected function isAssoc(array $array)
+    protected function isAssoc(array $array): bool
     {
         return count(array_filter(array_keys($array), 'is_string')) > 0;
     }
@@ -71,7 +71,7 @@ class ServerResponse extends Entity
      *
      * @return bool
      */
-    public function isOk()
+    public function isOk(): bool
     {
         return (bool) $this->getOk();
     }
@@ -106,7 +106,7 @@ class ServerResponse extends Entity
      *
      * @return Chat|ChatMember|File|Message|User|UserProfilePhotos|WebhookInfo
      */
-    private function createResultObject(array $result, $bot_username)
+    private function createResultObject(array $result, string $bot_username)
     {
         $action = Request::getCurrentAction();
 
@@ -136,7 +136,7 @@ class ServerResponse extends Entity
      *
      * @return BotCommand[]|ChatMember[]|GameHighScore[]|Message[]|Update[]
      */
-    private function createResultObjects(array $result, $bot_username)
+    private function createResultObjects(array $result, string $bot_username): array
     {
         $results = [];
         $action  = Request::getCurrentAction();

--- a/src/Entities/Sticker.php
+++ b/src/Entities/Sticker.php
@@ -32,7 +32,7 @@ class Sticker extends Entity
     /**
      * {@inheritdoc}
      */
-    protected function subEntities()
+    protected function subEntities(): array
     {
         return [
             'thumb'         => PhotoSize::class,

--- a/src/Entities/StickerSet.php
+++ b/src/Entities/StickerSet.php
@@ -28,7 +28,7 @@ class StickerSet extends Entity
     /**
      * {@inheritdoc}
      */
-    protected function subEntities()
+    protected function subEntities(): array
     {
         return [
             'stickers' => [Sticker::class],

--- a/src/Entities/TelegramPassport/EncryptedPassportElement.php
+++ b/src/Entities/TelegramPassport/EncryptedPassportElement.php
@@ -36,7 +36,7 @@ class EncryptedPassportElement extends Entity
     /**
      * {@inheritdoc}
      */
-    protected function subEntities()
+    protected function subEntities(): array
     {
         return [
             'files'        => [PassportFile::class],

--- a/src/Entities/TelegramPassport/PassportData.php
+++ b/src/Entities/TelegramPassport/PassportData.php
@@ -28,7 +28,7 @@ class PassportData extends Entity
     /**
      * {@inheritdoc}
      */
-    protected function subEntities()
+    protected function subEntities(): array
     {
         return [
             'data'        => [EncryptedPassportElement::class],

--- a/src/Entities/Update.php
+++ b/src/Entities/Update.php
@@ -37,7 +37,7 @@ class Update extends Entity
     /**
      * {@inheritdoc}
      */
-    protected function subEntities()
+    protected function subEntities(): array
     {
         return [
             'message'              => Message::class,
@@ -59,7 +59,7 @@ class Update extends Entity
      *
      * @return string|null
      */
-    public function getUpdateType()
+    public function getUpdateType(): ?string
     {
         $types = array_keys($this->subEntities());
         foreach ($types as $type) {

--- a/src/Entities/UserProfilePhotos.php
+++ b/src/Entities/UserProfilePhotos.php
@@ -23,7 +23,7 @@ class UserProfilePhotos extends Entity
     /**
      * {@inheritdoc}
      */
-    protected function subEntities()
+    protected function subEntities(): array
     {
         return [
             'photos' => PhotoSize::class,
@@ -37,7 +37,7 @@ class UserProfilePhotos extends Entity
      *
      * @return PhotoSize[][]
      */
-    public function getPhotos()
+    public function getPhotos(): array
     {
         $all_photos = [];
 

--- a/src/Entities/Venue.php
+++ b/src/Entities/Venue.php
@@ -27,7 +27,7 @@ class Venue extends Entity
     /**
      * {@inheritdoc}
      */
-    protected function subEntities()
+    protected function subEntities(): array
     {
         return [
             'location' => Location::class,

--- a/src/Entities/Video.php
+++ b/src/Entities/Video.php
@@ -30,7 +30,7 @@ class Video extends Entity
     /**
      * {@inheritdoc}
      */
-    protected function subEntities()
+    protected function subEntities(): array
     {
         return [
             'thumb' => PhotoSize::class,

--- a/src/Entities/VideoNote.php
+++ b/src/Entities/VideoNote.php
@@ -28,7 +28,7 @@ class VideoNote extends Entity
     /**
      * {@inheritdoc}
      */
-    protected function subEntities()
+    protected function subEntities(): array
     {
         return [
             'thumb' => PhotoSize::class,

--- a/src/Exception/InvalidBotTokenException.php
+++ b/src/Exception/InvalidBotTokenException.php
@@ -21,6 +21,6 @@ class InvalidBotTokenException extends TelegramException
      */
     public function __construct()
     {
-        parent::__construct("Invalid bot token!");
+        parent::__construct('Invalid bot token!');
     }
 }

--- a/src/Exception/TelegramLogException.php
+++ b/src/Exception/TelegramLogException.php
@@ -14,7 +14,7 @@ namespace Longman\TelegramBot\Exception;
 /**
  * Main exception class used for exception handling
  */
-class TelegramLogException extends \Exception
+class TelegramLogException extends TelegramException
 {
 
 }

--- a/src/Telegram.php
+++ b/src/Telegram.php
@@ -53,9 +53,9 @@ class Telegram
     /**
      * Telegram Bot id
      *
-     * @var string
+     * @var int
      */
-    protected $bot_id = '';
+    protected $bot_id = 0;
 
     /**
      * Raw request data (json) for webhook methods
@@ -191,7 +191,7 @@ class Telegram
         if (!isset($matches[1])) {
             throw new TelegramException('Invalid API KEY defined!');
         }
-        $this->bot_id  = $matches[1];
+        $this->bot_id  = (int) $matches[1];
         $this->api_key = $api_key;
 
         $this->bot_username = $bot_username;
@@ -307,7 +307,7 @@ class Telegram
             } else {
                 $command_namespace = __NAMESPACE__ . '\\Commands\\' . $auth . 'Commands';
             }
-            $command_class = $command_namespace . '\\' . $this->ucfirstUnicode($command) . 'Command';
+            $command_class = $command_namespace . '\\' . $this->ucFirstUnicode($command) . 'Command';
 
             if (class_exists($command_class)) {
                 $command_obj = new $command_class($this, $this->update);
@@ -499,7 +499,7 @@ class Telegram
      */
     protected function getCommandFromType(string $type): string
     {
-        return $this->ucfirstUnicode(str_replace('_', '', $type));
+        return $this->ucFirstUnicode(str_replace('_', '', $type));
     }
 
     /**
@@ -615,7 +615,7 @@ class Telegram
      */
     protected function sanitizeCommand(string $command): string
     {
-        return str_replace(' ', '', $this->ucwordsUnicode(str_replace('_', ' ', $command)));
+        return str_replace(' ', '', $this->ucWordsUnicode(str_replace('_', ' ', $command)));
     }
 
     /**
@@ -858,9 +858,9 @@ class Telegram
     /**
      * Get Bot Id
      *
-     * @return string
+     * @return int
      */
-    public function getBotId(): string
+    public function getBotId(): int
     {
         return $this->bot_id;
     }
@@ -940,7 +940,7 @@ class Telegram
      *
      * @return string
      */
-    protected function ucwordsUnicode(string $str, string $encoding = 'UTF-8'): string
+    protected function ucWordsUnicode(string $str, string $encoding = 'UTF-8'): string
     {
         return mb_convert_case($str, MB_CASE_TITLE, $encoding);
     }
@@ -953,7 +953,7 @@ class Telegram
      *
      * @return string
      */
-    protected function ucfirstUnicode(string $str, string $encoding = 'UTF-8'): string
+    protected function ucFirstUnicode(string $str, string $encoding = 'UTF-8'): string
     {
         return mb_strtoupper(mb_substr($str, 0, 1, $encoding), $encoding)
             . mb_strtolower(mb_substr($str, 1, mb_strlen($str), $encoding), $encoding);
@@ -1026,8 +1026,11 @@ class Telegram
             ]);
         };
 
-        $this->update           = $newUpdate();   // Required for isAdmin() check inside getCommandObject()
-        $this->commands_objects = $this->getCommandsList();       // Load up-to-date commands list
+        // Required for isAdmin() check inside getCommandObject()
+        $this->update = $newUpdate();
+
+        // Load up-to-date commands list
+        $this->commands_objects = $this->getCommandsList();
 
         foreach ($commands as $command) {
             $this->update = $newUpdate($command);

--- a/src/Telegram.php
+++ b/src/Telegram.php
@@ -62,7 +62,7 @@ class Telegram
      *
      * @var string
      */
-    protected $input;
+    protected $input = '';
 
     /**
      * Custom commands paths
@@ -152,19 +152,19 @@ class Telegram
      * Last update ID
      * Only used when running getUpdates without a database
      *
-     * @var integer
+     * @var int
      */
     protected $last_update_id;
 
     /**
      * The command to be executed when there's a new message update and nothing more suitable is found
      */
-    const GENERIC_MESSAGE_COMMAND = 'genericmessage';
+    public const GENERIC_MESSAGE_COMMAND = 'genericmessage';
 
     /**
      * The command to be executed by default (when no other relevant commands are applicable)
      */
-    const GENERIC_COMMAND = 'generic';
+    public const GENERIC_COMMAND = 'generic';
 
     /**
      * Update filter
@@ -182,21 +182,19 @@ class Telegram
      *
      * @throws TelegramException
      */
-    public function __construct($api_key, $bot_username = '')
+    public function __construct(string $api_key, string $bot_username = '')
     {
         if (empty($api_key)) {
             throw new TelegramException('API KEY not defined!');
         }
-        preg_match('/(\d+)\:[\w\-]+/', $api_key, $matches);
+        preg_match('/(\d+):[\w\-]+/', $api_key, $matches);
         if (!isset($matches[1])) {
             throw new TelegramException('Invalid API KEY defined!');
         }
         $this->bot_id  = $matches[1];
         $this->api_key = $api_key;
 
-        if (!empty($bot_username)) {
-            $this->bot_username = $bot_username;
-        }
+        $this->bot_username = $bot_username;
 
         //Add default system commands path
         $this->addCommandsPath(TB_BASE_COMMANDS_PATH . '/SystemCommands');
@@ -207,16 +205,16 @@ class Telegram
     /**
      * Initialize Database connection
      *
-     * @param array  $credential
+     * @param array  $credentials
      * @param string $table_prefix
      * @param string $encoding
      *
      * @return Telegram
      * @throws TelegramException
      */
-    public function enableMySql(array $credential, $table_prefix = null, $encoding = 'utf8mb4')
+    public function enableMySql(array $credentials, string $table_prefix = '', string $encoding = 'utf8mb4'): Telegram
     {
-        $this->pdo = DB::initialize($credential, $this, $table_prefix, $encoding);
+        $this->pdo = DB::initialize($credentials, $this, $table_prefix, $encoding);
         ConversationDB::initializeConversation();
         $this->mysql_enabled = true;
 
@@ -232,7 +230,7 @@ class Telegram
      * @return Telegram
      * @throws TelegramException
      */
-    public function enableExternalMySql($external_pdo_connection, $table_prefix = null)
+    public function enableExternalMySql(PDO $external_pdo_connection, string $table_prefix = ''): Telegram
     {
         $this->pdo = DB::externalInitialize($external_pdo_connection, $this, $table_prefix);
         ConversationDB::initializeConversation();
@@ -247,7 +245,7 @@ class Telegram
      * @return array $commands
      * @throws TelegramException
      */
-    public function getCommandsList()
+    public function getCommandsList(): array
     {
         $commands = [];
 
@@ -293,7 +291,7 @@ class Telegram
      *
      * @return Command|null
      */
-    public function getCommandObject($command, $filepath = null)
+    public function getCommandObject(string $command, string $filepath = ''): ?Command
     {
         if (isset($this->commands_objects[$command])) {
             return $this->commands_objects[$command];
@@ -344,14 +342,15 @@ class Telegram
      *
      * @param string $src (absolute path to file)
      *
-     * @return string ("Longman\TelegramBot\Commands\SystemCommands" for example)
+     * @return string|null ("Longman\TelegramBot\Commands\SystemCommands" for example)
      */
-    protected function getFileNamespace($src)
+    protected function getFileNamespace(string $src): ?string
     {
         $content = file_get_contents($src);
         if (preg_match('#^namespace\s+(.+?);#m', $content, $m)) {
             return $m[1];
         }
+
         return null;
     }
 
@@ -362,7 +361,7 @@ class Telegram
      *
      * @return Telegram
      */
-    public function setCustomInput($input)
+    public function setCustomInput(string $input): Telegram
     {
         $this->input = $input;
 
@@ -374,7 +373,7 @@ class Telegram
      *
      * @return string
      */
-    public function getCustomInput()
+    public function getCustomInput(): string
     {
         return $this->input;
     }
@@ -384,7 +383,7 @@ class Telegram
      *
      * @return ServerResponse
      */
-    public function getLastCommandResponse()
+    public function getLastCommandResponse(): ServerResponse
     {
         return $this->last_command_response;
     }
@@ -392,13 +391,13 @@ class Telegram
     /**
      * Handle getUpdates method
      *
-     * @param int|null $limit
-     * @param int|null $timeout
+     * @param int $limit
+     * @param int $timeout
      *
      * @return ServerResponse
      * @throws TelegramException
      */
-    public function handleGetUpdates($limit = null, $timeout = null)
+    public function handleGetUpdates(int $limit = 0, int $timeout = 0): ServerResponse
     {
         if (empty($this->bot_username)) {
             throw new TelegramException('Bot Username is not defined!');
@@ -424,20 +423,18 @@ class Telegram
                 //Get last update id from the database
                 $last_update = reset($last_update);
 
-                $this->last_update_id = isset($last_update['id']) ? $last_update['id'] : null;
+                $this->last_update_id = $last_update['id'] ?? null;
             }
 
             if ($this->last_update_id !== null) {
                 $offset = $this->last_update_id + 1;    //As explained in the telegram bot API documentation
             }
 
-            $response = Request::getUpdates(
-                [
-                    'offset'  => $offset,
-                    'limit'   => $limit,
-                    'timeout' => $timeout,
-                ]
-            );
+            $response = Request::getUpdates([
+                'offset'  => $offset,
+                'limit'   => $limit,
+                'timeout' => $timeout,
+            ]);
         }
 
         if ($response->isOk()) {
@@ -451,13 +448,11 @@ class Telegram
 
             if (!DB::isDbConnected() && !$custom_input && $this->last_update_id !== null && $offset === 0) {
                 //Mark update(s) as read after handling
-                Request::getUpdates(
-                    [
-                        'offset'  => $this->last_update_id + 1,
-                        'limit'   => 1,
-                        'timeout' => $timeout,
-                    ]
-                );
+                Request::getUpdates([
+                    'offset'  => $this->last_update_id + 1,
+                    'limit'   => 1,
+                    'timeout' => $timeout,
+                ]);
             }
         }
 
@@ -471,9 +466,9 @@ class Telegram
      *
      * @throws TelegramException
      */
-    public function handle()
+    public function handle(): bool
     {
-        if (empty($this->bot_username)) {
+        if ($this->bot_username === '') {
             throw new TelegramException('Bot Username is not defined!');
         }
 
@@ -502,7 +497,7 @@ class Telegram
      *
      * @return string
      */
-    protected function getCommandFromType($type)
+    protected function getCommandFromType(string $type): string
     {
         return $this->ucfirstUnicode(str_replace('_', '', $type));
     }
@@ -515,7 +510,7 @@ class Telegram
      * @return ServerResponse
      * @throws TelegramException
      */
-    public function processUpdate(Update $update)
+    public function processUpdate(Update $update): ServerResponse
     {
         $this->update         = $update;
         $this->last_update_id = $update->getUpdateId();
@@ -530,7 +525,7 @@ class Telegram
 
             if (!$allowed) {
                 TelegramLog::debug($reason);
-                return new ServerResponse(['ok' => false, 'description' => 'denied'], null);
+                return new ServerResponse(['ok' => false, 'description' => 'denied']);
             }
         }
 
@@ -554,7 +549,7 @@ class Telegram
             // Let's check if the message object has the type field we're looking for...
             $command_tmp = $type === 'command' ? $message->getCommand() : $this->getCommandFromType($type);
             // ...and if a fitting command class is available.
-            $command_obj = $this->getCommandObject($command_tmp);
+            $command_obj = $command_tmp ? $this->getCommandObject($command_tmp) : null;
 
             // Empty usage string denotes a non-executable command.
             // @see https://github.com/php-telegram-bot/core/issues/772#issuecomment-388616072
@@ -564,7 +559,7 @@ class Telegram
             ) {
                 $command = $command_tmp;
             }
-        } else {
+        } elseif ($update_type !== null) {
             $command = $this->getCommandFromType($update_type);
         }
 
@@ -588,15 +583,11 @@ class Telegram
      * @return ServerResponse
      * @throws TelegramException
      */
-    public function executeCommand($command)
+    public function executeCommand(string $command): ServerResponse
     {
         $command = mb_strtolower($command);
 
-        if (isset($this->commands_objects[$command])) {
-            $command_obj = $this->commands_objects[$command];
-        } else {
-            $command_obj = $this->getCommandObject($command);
-        }
+        $command_obj = $this->commands_objects[$command] ?? $this->getCommandObject($command);
 
         if (!$command_obj || !$command_obj->isEnabled()) {
             //Failsafe in case the Generic command can't be found
@@ -622,7 +613,7 @@ class Telegram
      *
      * @return string
      */
-    protected function sanitizeCommand($command)
+    protected function sanitizeCommand(string $command): string
     {
         return str_replace(' ', '', $this->ucwordsUnicode(str_replace('_', ' ', $command)));
     }
@@ -630,13 +621,13 @@ class Telegram
     /**
      * Enable a single Admin account
      *
-     * @param integer $admin_id Single admin id
+     * @param int $admin_id Single admin id
      *
      * @return Telegram
      */
-    public function enableAdmin($admin_id)
+    public function enableAdmin(int $admin_id): Telegram
     {
-        if (!is_int($admin_id) || $admin_id <= 0) {
+        if ($admin_id <= 0) {
             TelegramLog::error('Invalid value "' . $admin_id . '" for admin.');
         } elseif (!in_array($admin_id, $this->admins_list, true)) {
             $this->admins_list[] = $admin_id;
@@ -652,7 +643,7 @@ class Telegram
      *
      * @return Telegram
      */
-    public function enableAdmins(array $admin_ids)
+    public function enableAdmins(array $admin_ids): Telegram
     {
         foreach ($admin_ids as $admin_id) {
             $this->enableAdmin($admin_id);
@@ -666,7 +657,7 @@ class Telegram
      *
      * @return array
      */
-    public function getAdminList()
+    public function getAdminList(): array
     {
         return $this->admins_list;
     }
@@ -680,7 +671,7 @@ class Telegram
      *
      * @return bool
      */
-    public function isAdmin($user_id = null)
+    public function isAdmin($user_id = null): bool
     {
         if ($user_id === null && $this->update !== null) {
             //Try to figure out if the user is an admin
@@ -710,13 +701,9 @@ class Telegram
      *
      * @return bool
      */
-    public function isDbEnabled()
+    public function isDbEnabled(): bool
     {
-        if ($this->mysql_enabled) {
-            return true;
-        } else {
-            return false;
-        }
+        return $this->mysql_enabled;
     }
 
     /**
@@ -727,7 +714,7 @@ class Telegram
      *
      * @return Telegram
      */
-    public function addCommandsPath($path, $before = true)
+    public function addCommandsPath(string $path, bool $before = true): Telegram
     {
         if (!is_dir($path)) {
             TelegramLog::error('Commands path "' . $path . '" does not exist.');
@@ -750,7 +737,7 @@ class Telegram
      *
      * @return Telegram
      */
-    public function addCommandsPaths(array $paths, $before = true)
+    public function addCommandsPaths(array $paths, $before = true): Telegram
     {
         foreach ($paths as $path) {
             $this->addCommandsPath($path, $before);
@@ -764,7 +751,7 @@ class Telegram
      *
      * @return array
      */
-    public function getCommandsPaths()
+    public function getCommandsPaths(): array
     {
         return $this->commands_paths;
     }
@@ -776,7 +763,7 @@ class Telegram
      *
      * @return Telegram
      */
-    public function setUploadPath($path)
+    public function setUploadPath(string $path): Telegram
     {
         $this->upload_path = $path;
 
@@ -788,7 +775,7 @@ class Telegram
      *
      * @return string
      */
-    public function getUploadPath()
+    public function getUploadPath(): string
     {
         return $this->upload_path;
     }
@@ -800,7 +787,7 @@ class Telegram
      *
      * @return Telegram
      */
-    public function setDownloadPath($path)
+    public function setDownloadPath(string $path): Telegram
     {
         $this->download_path = $path;
 
@@ -812,7 +799,7 @@ class Telegram
      *
      * @return string
      */
-    public function getDownloadPath()
+    public function getDownloadPath(): string
     {
         return $this->download_path;
     }
@@ -829,7 +816,7 @@ class Telegram
      *
      * @return Telegram
      */
-    public function setCommandConfig($command, array $config)
+    public function setCommandConfig(string $command, array $config): Telegram
     {
         $this->commands_config[$command] = $config;
 
@@ -843,9 +830,9 @@ class Telegram
      *
      * @return array
      */
-    public function getCommandConfig($command)
+    public function getCommandConfig(string $command): array
     {
-        return isset($this->commands_config[$command]) ? $this->commands_config[$command] : [];
+        return $this->commands_config[$command] ?? [];
     }
 
     /**
@@ -853,7 +840,7 @@ class Telegram
      *
      * @return string
      */
-    public function getApiKey()
+    public function getApiKey(): string
     {
         return $this->api_key;
     }
@@ -863,7 +850,7 @@ class Telegram
      *
      * @return string
      */
-    public function getBotUsername()
+    public function getBotUsername(): string
     {
         return $this->bot_username;
     }
@@ -873,7 +860,7 @@ class Telegram
      *
      * @return string
      */
-    public function getBotId()
+    public function getBotId(): string
     {
         return $this->bot_id;
     }
@@ -883,7 +870,7 @@ class Telegram
      *
      * @return string
      */
-    public function getVersion()
+    public function getVersion(): string
     {
         return $this->version;
     }
@@ -897,9 +884,9 @@ class Telegram
      * @return ServerResponse
      * @throws TelegramException
      */
-    public function setWebhook($url, array $data = [])
+    public function setWebhook(string $url, array $data = []): ServerResponse
     {
-        if (empty($url)) {
+        if ($url === '') {
             throw new TelegramException('Hook url is empty!');
         }
 
@@ -953,7 +940,7 @@ class Telegram
      *
      * @return string
      */
-    protected function ucwordsUnicode($str, $encoding = 'UTF-8')
+    protected function ucwordsUnicode(string $str, string $encoding = 'UTF-8'): string
     {
         return mb_convert_case($str, MB_CASE_TITLE, $encoding);
     }
@@ -966,7 +953,7 @@ class Telegram
      *
      * @return string
      */
-    protected function ucfirstUnicode($str, $encoding = 'UTF-8')
+    protected function ucfirstUnicode(string $str, string $encoding = 'UTF-8'): string
     {
         return mb_strtoupper(mb_substr($str, 0, 1, $encoding), $encoding)
             . mb_strtolower(mb_substr($str, 1, mb_strlen($str), $encoding), $encoding);
@@ -980,7 +967,7 @@ class Telegram
      * @return Telegram
      * @throws TelegramException
      */
-    public function enableLimiter(array $options = [])
+    public function enableLimiter(array $options = []): Telegram
     {
         Request::setLimiter(true, $options);
 
@@ -994,9 +981,9 @@ class Telegram
      *
      * @throws TelegramException
      */
-    public function runCommands($commands)
+    public function runCommands(array $commands): void
     {
-        if (!is_array($commands) || empty($commands)) {
+        if (empty($commands)) {
             throw new TelegramException('No command(s) provided!');
         }
 
@@ -1020,28 +1007,26 @@ class Telegram
         $this->enableAdmin($bot_id);
 
         $newUpdate = static function ($text = '') use ($bot_id, $bot_name, $bot_username) {
-            return new Update(
-                [
-                    'update_id' => 0,
-                    'message'   => [
-                        'message_id' => 0,
-                        'from'       => [
-                            'id'         => $bot_id,
-                            'first_name' => $bot_name,
-                            'username'   => $bot_username,
-                        ],
-                        'date'       => time(),
-                        'chat'       => [
-                            'id'   => $bot_id,
-                            'type' => 'private',
-                        ],
-                        'text'       => $text,
+            return new Update([
+                'update_id' => 0,
+                'message'   => [
+                    'message_id' => 0,
+                    'from'       => [
+                        'id'         => $bot_id,
+                        'first_name' => $bot_name,
+                        'username'   => $bot_username,
                     ],
-                ]
-            );
+                    'date'       => time(),
+                    'chat'       => [
+                        'id'   => $bot_id,
+                        'type' => 'private',
+                    ],
+                    'text'       => $text,
+                ],
+            ]);
         };
 
-        $this->update = $newUpdate();   // Required for isAdmin() check inside getCommandObject()
+        $this->update           = $newUpdate();   // Required for isAdmin() check inside getCommandObject()
         $this->commands_objects = $this->getCommandsList();       // Load up-to-date commands list
 
         foreach ($commands as $command) {
@@ -1056,7 +1041,7 @@ class Telegram
      *
      * @return bool
      */
-    public function isRunCommands()
+    public function isRunCommands(): bool
     {
         return $this->run_commands;
     }
@@ -1065,10 +1050,14 @@ class Telegram
      * Switch to enable running getUpdates without a database
      *
      * @param bool $enable
+     *
+     * @return Telegram
      */
-    public function useGetUpdatesWithoutDatabase($enable = true)
+    public function useGetUpdatesWithoutDatabase(bool $enable = true): Telegram
     {
         $this->getupdates_without_database = $enable;
+
+        return $this;
     }
 
     /**
@@ -1076,7 +1065,7 @@ class Telegram
      *
      * @return int
      */
-    public function getLastUpdateId()
+    public function getLastUpdateId(): int
     {
         return $this->last_update_id;
     }
@@ -1088,7 +1077,7 @@ class Telegram
      *
      * @return Telegram
      */
-    public function setUpdateFilter(callable $callback)
+    public function setUpdateFilter(callable $callback): Telegram
     {
         $this->update_filter = $callback;
 
@@ -1100,7 +1089,7 @@ class Telegram
      *
      * @return callable|null
      */
-    public function getUpdateFilter()
+    public function getUpdateFilter(): ?callable
     {
         return $this->update_filter;
     }

--- a/src/TelegramLog.php
+++ b/src/TelegramLog.php
@@ -70,7 +70,7 @@ class TelegramLog
      * @param LoggerInterface|null $logger
      * @param LoggerInterface|null $update_logger
      */
-    public static function initialize(LoggerInterface $logger = null, LoggerInterface $update_logger = null)
+    public static function initialize(LoggerInterface $logger = null, LoggerInterface $update_logger = null): void
     {
         self::$logger        = $logger ?: new NullLogger();
         self::$update_logger = $update_logger ?: new NullLogger();
@@ -95,14 +95,14 @@ class TelegramLog
      *
      * @param string $message Message (with placeholder) to write to the debug log
      */
-    public static function endDebugLogTempStream($message = '%s')
+    public static function endDebugLogTempStream($message = '%s'): void
     {
         if (is_resource(self::$debug_log_temp_stream_handle)) {
             rewind(self::$debug_log_temp_stream_handle);
             $stream_contents = stream_get_contents(self::$debug_log_temp_stream_handle);
 
             if (self::$remove_bot_token) {
-                $stream_contents = preg_replace('/\/bot(\d+)\:[\w\-]+\//', '/botBOT_TOKEN_REMOVED/', $stream_contents);
+                $stream_contents = preg_replace('/\/bot(\d+):[\w\-]+\//', '/botBOT_TOKEN_REMOVED/', $stream_contents);
             }
 
             self::debug(sprintf($message, $stream_contents));
@@ -117,7 +117,7 @@ class TelegramLog
      * @param string $name
      * @param array  $arguments
      */
-    public static function __callStatic($name, array $arguments)
+    public static function __callStatic(string $name, array $arguments)
     {
         // Get the correct logger instance.
         $logger = null;
@@ -151,7 +151,7 @@ class TelegramLog
      *
      * @return string
      */
-    protected static function interpolate($message, array $context = [])
+    protected static function interpolate(string $message, array $context = []): string
     {
         // Build a replacement array with braces around the context keys.
         $replace = [];

--- a/tests/Unit/Commands/CommandTest.php
+++ b/tests/Unit/Commands/CommandTest.php
@@ -17,11 +17,11 @@ use Longman\TelegramBot\Tests\Unit\TestCase;
 use Longman\TelegramBot\Tests\Unit\TestHelpers;
 
 /**
- * @package         TelegramTest
+ * @link            https://github.com/php-telegram-bot/core
  * @author          Avtandil Kikabidze <akalongman@gmail.com>
  * @copyright       Avtandil Kikabidze <akalongman@gmail.com>
  * @license         http://opensource.org/licenses/mit-license.php  The MIT License (MIT)
- * @link            https://github.com/php-telegram-bot/core
+ * @package         TelegramTest
  */
 class CommandTest extends TestCase
 {
@@ -68,7 +68,7 @@ class CommandTest extends TestCase
     }
 
     // Test idea from here: http://stackoverflow.com/a/4371606
-    public function testCommandConstructorNeedsTelegramObject()
+    public function testCommandConstructorNeedsTelegramObject(): void
     {
         $exception_count = 0;
         $params_to_test  = [
@@ -83,97 +83,89 @@ class CommandTest extends TestCase
         foreach ($params_to_test as $param) {
             try {
                 $this->getMockForAbstractClass($this->command_namespace, $param);
-            } catch (\Exception $e) {
-                $exception_count++;
-            } catch (\Throwable $e) { //For PHP7
+            } catch (\Throwable $e) {
                 $exception_count++;
             }
         }
 
-        $this->assertEquals(5, $exception_count);
+        self::assertEquals(5, $exception_count);
     }
 
-    public function testCommandHasCorrectTelegramObject()
+    public function testCommandHasCorrectTelegramObject(): void
     {
-        $this->assertSame($this->telegram, $this->command_stub->getTelegram());
+        self::assertSame($this->telegram, $this->command_stub->getTelegram());
     }
 
-    public function testDefaultCommandName()
+    public function testDefaultCommandName(): void
     {
-        $this->assertEmpty($this->command_stub->getName());
+        self::assertEmpty($this->command_stub->getName());
     }
 
-    public function testDefaultCommandDescription()
+    public function testDefaultCommandDescription(): void
     {
-        $this->assertEquals('Command description', $this->command_stub->getDescription());
+        self::assertEquals('Command description', $this->command_stub->getDescription());
     }
 
-    public function testDefaultCommandUsage()
+    public function testDefaultCommandUsage(): void
     {
-        $this->assertEquals('Command usage', $this->command_stub->getUsage());
+        self::assertEquals('Command usage', $this->command_stub->getUsage());
     }
 
-    public function testDefaultCommandVersion()
+    public function testDefaultCommandVersion(): void
     {
-        $this->assertEquals('1.0.0', $this->command_stub->getVersion());
+        self::assertEquals('1.0.0', $this->command_stub->getVersion());
     }
 
-    public function testDefaultCommandIsEnabled()
+    public function testDefaultCommandIsEnabled(): void
     {
-        $this->assertTrue($this->command_stub->isEnabled());
+        self::assertTrue($this->command_stub->isEnabled());
     }
 
-    public function testDefaultCommandShownInHelp()
+    public function testDefaultCommandShownInHelp(): void
     {
-        $this->assertTrue($this->command_stub->showInHelp());
+        self::assertTrue($this->command_stub->showInHelp());
     }
 
-    public function testDefaultCommandNeedsMysql()
+    public function testDefaultCommandNeedsMysql(): void
     {
-        $this->markTestSkipped('Think about better test');
-        $this->assertAttributeEquals(false, 'need_mysql', $this->command_stub);
+        self::markTestSkipped('Think about better test');
     }
 
-    public function testDefaultCommandEmptyConfig()
+    public function testDefaultCommandEmptyConfig(): void
     {
-        $this->assertSame([], $this->command_stub->getConfig());
+        self::assertSame([], $this->command_stub->getConfig());
     }
 
-    public function testDefaultCommandUpdateNull()
+    public function testDefaultCommandUpdateNull(): void
     {
-        $this->assertNull($this->command_stub->getUpdate());
+        self::assertNull($this->command_stub->getUpdate());
     }
 
-    public function testCommandSetUpdateAndMessage()
+    public function testCommandSetUpdateAndMessage(): void
     {
         $stub = $this->command_stub;
 
-        $this->assertSame($stub, $stub->setUpdate());
-        $this->assertEquals(null, $stub->getUpdate());
-        $this->assertEquals(null, $stub->getMessage());
-
-        $this->assertSame($stub, $stub->setUpdate(null));
-        $this->assertEquals(null, $stub->getUpdate());
-        $this->assertEquals(null, $stub->getMessage());
+        self::assertEquals(null, $stub->getUpdate());
+        self::assertEquals(null, $stub->getMessage());
 
         $update  = TestHelpers::getFakeUpdateObject();
         $message = $update->getMessage();
         $stub->setUpdate($update);
-        $this->assertEquals($update, $stub->getUpdate());
-        $this->assertEquals($message, $stub->getMessage());
+        self::assertEquals($update, $stub->getUpdate());
+        self::assertEquals($message, $stub->getMessage());
     }
 
-    public function testCommandWithConfigNotEmptyConfig()
+    public function testCommandWithConfigNotEmptyConfig(): void
     {
-        $this->assertNotEmpty($this->command_stub_with_config->getConfig());
+        self::assertNotEmpty($this->command_stub_with_config->getConfig());
     }
 
-    public function testCommandWithConfigCorrectConfig()
+    public function testCommandWithConfigCorrectConfig(): void
     {
-        $this->assertEquals(['config_key' => 'config_value'], $this->command_stub_with_config->getConfig());
-        $this->assertEquals(['config_key' => 'config_value'], $this->command_stub_with_config->getConfig(null));
-        $this->assertEquals(['config_key' => 'config_value'], $this->command_stub_with_config->getConfig());
-        $this->assertEquals('config_value', $this->command_stub_with_config->getConfig('config_key'));
-        $this->assertEquals(null, $this->command_stub_with_config->getConfig('not_config_key'));
+        self::assertEquals(['config_key' => 'config_value'], $this->command_stub_with_config->getConfig());
+        self::assertEquals(['config_key' => 'config_value'], $this->command_stub_with_config->getConfig(null));
+        self::assertEquals(['config_key' => 'config_value'], $this->command_stub_with_config->getConfig());
+        self::assertEquals('config_value', $this->command_stub_with_config->getConfig('config_key'));
+        self::assertEquals(null, $this->command_stub_with_config->getConfig('not_config_key'));
     }
 }

--- a/tests/Unit/Commands/CommandTestCase.php
+++ b/tests/Unit/Commands/CommandTestCase.php
@@ -49,8 +49,8 @@ class CommandTestCase extends TestCase
     /**
      * Make sure the version number is in the format x.x.x, x.x or x
      */
-    public function testVersionNumberFormat()
+    public function testVersionNumberFormat(): void
     {
-        $this->assertRegExp('/^(\d+\\.)?(\d+\\.)?(\d+)$/', $this->command->getVersion());
+        self::assertRegExp('/^(\d+\\.)?(\d+\\.)?(\d+)$/', $this->command->getVersion());
     }
 }

--- a/tests/Unit/Commands/CustomTestCommands/HiddenCommand.php
+++ b/tests/Unit/Commands/CustomTestCommands/HiddenCommand.php
@@ -12,6 +12,7 @@
 namespace Longman\TelegramBot\Commands\UserCommands;
 
 use Longman\TelegramBot\Commands\UserCommand;
+use Longman\TelegramBot\Entities\ServerResponse;
 use Longman\TelegramBot\Request;
 
 /**
@@ -49,7 +50,7 @@ class HiddenCommand extends UserCommand
      *
      * @return mixed
      */
-    public function execute()
+    public function execute(): ServerResponse
     {
         return Request::emptyResponse();
     }

--- a/tests/Unit/Commands/CustomTestCommands/VisibleCommand.php
+++ b/tests/Unit/Commands/CustomTestCommands/VisibleCommand.php
@@ -12,6 +12,7 @@
 namespace Longman\TelegramBot\Commands\UserCommands;
 
 use Longman\TelegramBot\Commands\UserCommand;
+use Longman\TelegramBot\Entities\ServerResponse;
 use Longman\TelegramBot\Request;
 
 /**
@@ -49,7 +50,7 @@ class VisibleCommand extends UserCommand
      *
      * @return mixed
      */
-    public function execute()
+    public function execute(): ServerResponse
     {
         return Request::emptyResponse();
     }

--- a/tests/Unit/ConversationTest.php
+++ b/tests/Unit/ConversationTest.php
@@ -46,75 +46,75 @@ class ConversationTest extends TestCase
         TestHelpers::emptyDb($credentials);
     }
 
-    public function testConversationThatDoesntExistPropertiesSetCorrectly()
+    public function testConversationThatDoesntExistPropertiesSetCorrectly(): void
     {
         $conversation = new Conversation(123, 456);
-        $this->assertSame(123, $conversation->getUserId());
-        $this->assertSame(456, $conversation->getChatId());
-        $this->assertNull($conversation->getCommand());
+        self::assertSame(123, $conversation->getUserId());
+        self::assertSame(456, $conversation->getChatId());
+        self::assertEmpty($conversation->getCommand());
     }
 
-    public function testConversationThatExistsPropertiesSetCorrectly()
+    public function testConversationThatExistsPropertiesSetCorrectly(): void
     {
         $info         = TestHelpers::startFakeConversation();
         $conversation = new Conversation($info['user_id'], $info['chat_id'], 'command');
-        $this->assertSame($info['user_id'], $conversation->getUserId());
-        $this->assertSame($info['chat_id'], $conversation->getChatId());
-        $this->assertSame('command', $conversation->getCommand());
+        self::assertSame($info['user_id'], $conversation->getUserId());
+        self::assertSame($info['chat_id'], $conversation->getChatId());
+        self::assertSame('command', $conversation->getCommand());
     }
 
-    public function testConversationThatDoesntExistWithoutCommand()
+    public function testConversationThatDoesntExistWithoutCommand(): void
     {
         $conversation = new Conversation(1, 1);
-        $this->assertFalse($conversation->exists());
-        $this->assertNull($conversation->getCommand());
+        self::assertFalse($conversation->exists());
+        self::assertEmpty($conversation->getCommand());
     }
 
-    public function testConversationThatDoesntExistWithCommand()
+    public function testConversationThatDoesntExistWithCommand(): void
     {
         $this->expectException(TelegramException::class);
         new Conversation(1, 1, 'command');
     }
 
-    public function testNewConversationThatWontExistWithoutCommand()
+    public function testNewConversationThatWontExistWithoutCommand(): void
     {
         TestHelpers::startFakeConversation();
         $conversation = new Conversation(0, 0);
-        $this->assertFalse($conversation->exists());
-        $this->assertNull($conversation->getCommand());
+        self::assertFalse($conversation->exists());
+        self::assertEmpty($conversation->getCommand());
     }
 
-    public function testNewConversationThatWillExistWithCommand()
+    public function testNewConversationThatWillExistWithCommand(): void
     {
         $info         = TestHelpers::startFakeConversation();
         $conversation = new Conversation($info['user_id'], $info['chat_id'], 'command');
-        $this->assertTrue($conversation->exists());
-        $this->assertEquals('command', $conversation->getCommand());
+        self::assertTrue($conversation->exists());
+        self::assertEquals('command', $conversation->getCommand());
     }
 
-    public function testStopConversation()
+    public function testStopConversation(): void
     {
         $info         = TestHelpers::startFakeConversation();
         $conversation = new Conversation($info['user_id'], $info['chat_id'], 'command');
-        $this->assertTrue($conversation->exists());
+        self::assertTrue($conversation->exists());
         $conversation->stop();
 
         $conversation2 = new Conversation($info['user_id'], $info['chat_id']);
-        $this->assertFalse($conversation2->exists());
+        self::assertFalse($conversation2->exists());
     }
 
-    public function testCancelConversation()
+    public function testCancelConversation(): void
     {
         $info         = TestHelpers::startFakeConversation();
         $conversation = new Conversation($info['user_id'], $info['chat_id'], 'command');
-        $this->assertTrue($conversation->exists());
+        self::assertTrue($conversation->exists());
         $conversation->cancel();
 
         $conversation2 = new Conversation($info['user_id'], $info['chat_id']);
-        $this->assertFalse($conversation2->exists());
+        self::assertFalse($conversation2->exists());
     }
 
-    public function testUpdateConversationNotes()
+    public function testUpdateConversationNotes(): void
     {
         $info                = TestHelpers::startFakeConversation();
         $conversation        = new Conversation($info['user_id'], $info['chat_id'], 'command');
@@ -122,9 +122,9 @@ class ConversationTest extends TestCase
         $conversation->update();
 
         $conversation2 = new Conversation($info['user_id'], $info['chat_id'], 'command');
-        $this->assertSame('newnote', $conversation2->notes);
+        self::assertSame('newnote', $conversation2->notes);
 
         $conversation3 = new Conversation($info['user_id'], $info['chat_id']);
-        $this->assertSame('newnote', $conversation3->notes);
+        self::assertSame('newnote', $conversation3->notes);
     }
 }

--- a/tests/Unit/Entities/AudioTest.php
+++ b/tests/Unit/Entities/AudioTest.php
@@ -32,13 +32,13 @@ class AudioTest extends TestCase
         $this->record = TestHelpers::getFakeRecordedAudio();
     }
 
-    public function testInstance()
+    public function testInstance(): void
     {
         $audio = new Audio($this->record);
         self::assertInstanceOf(Audio::class, $audio);
     }
 
-    public function testGetProperties()
+    public function testGetProperties(): void
     {
         $audio = new Audio($this->record);
         self::assertEquals($this->record['file_id'], $audio->getFileId());

--- a/tests/Unit/Entities/ChatTest.php
+++ b/tests/Unit/Entities/ChatTest.php
@@ -20,7 +20,7 @@ namespace Longman\TelegramBot\Tests\Unit;
  */
 class ChatTest extends TestCase
 {
-    public function testChatType()
+    public function testChatType(): void
     {
         $chat = TestHelpers::getFakeChatObject();
         self::assertEquals('private', $chat->getType());
@@ -35,7 +35,7 @@ class ChatTest extends TestCase
         self::assertEquals('channel', $chat->getType());
     }
 
-    public function testIsChatType()
+    public function testIsChatType(): void
     {
         $chat = TestHelpers::getFakeChatObject();
         self::assertTrue($chat->isPrivateChat());
@@ -50,7 +50,7 @@ class ChatTest extends TestCase
         self::assertTrue($chat->isChannel());
     }
 
-    public function testTryMention()
+    public function testTryMention(): void
     {
         // Username.
         $chat = TestHelpers::getFakeChatObject(['id' => 1, 'first_name' => 'John', 'last_name' => 'Taylor', 'username' => 'jtaylor']);

--- a/tests/Unit/Entities/EntityTest.php
+++ b/tests/Unit/Entities/EntityTest.php
@@ -22,7 +22,7 @@ use Longman\TelegramBot\Entities\Entity;
  */
 class EntityTest extends TestCase
 {
-    public function testEscapeMarkdown()
+    public function testEscapeMarkdown(): void
     {
         // Make sure all characters that need escaping are escaped.
 

--- a/tests/Unit/Entities/FileTest.php
+++ b/tests/Unit/Entities/FileTest.php
@@ -36,48 +36,48 @@ class FileTest extends TestCase
         ];
     }
 
-    public function testBaseStageLocation()
+    public function testBaseStageLocation(): void
     {
         $file = new File($this->data);
-        $this->assertInstanceOf(File::class, $file);
+        self::assertInstanceOf(File::class, $file);
     }
 
-    public function testGetFileId()
+    public function testGetFileId(): void
     {
         $file = new File($this->data);
         $id   = $file->getFileId();
-        $this->assertIsInt($id);
-        $this->assertEquals($this->data['file_id'], $id);
+        self::assertIsInt($id);
+        self::assertEquals($this->data['file_id'], $id);
     }
 
-    public function testGetFileSize()
+    public function testGetFileSize(): void
     {
         $file = new File($this->data);
         $size = $file->getFileSize();
-        $this->assertIsInt($size);
-        $this->assertEquals($this->data['file_size'], $size);
+        self::assertIsInt($size);
+        self::assertEquals($this->data['file_size'], $size);
     }
 
-    public function testGetFilePath()
+    public function testGetFilePath(): void
     {
         $file = new File($this->data);
         $path = $file->getFilePath();
-        $this->assertEquals($this->data['file_path'], $path);
+        self::assertEquals($this->data['file_path'], $path);
     }
 
-    public function testGetFileSizeWithoutData()
+    public function testGetFileSizeWithoutData(): void
     {
         unset($this->data['file_size']);
         $file = new File($this->data);
         $id   = $file->getFileSize();
-        $this->assertNull($id);
+        self::assertNull($id);
     }
 
-    public function testGetFilePathWithoutData()
+    public function testGetFilePathWithoutData(): void
     {
         unset($this->data['file_path']);
         $file = new File($this->data);
         $path = $file->getFilePath();
-        $this->assertNull($path);
+        self::assertNull($path);
     }
 }

--- a/tests/Unit/Entities/InlineKeyboardButtonTest.php
+++ b/tests/Unit/Entities/InlineKeyboardButtonTest.php
@@ -24,21 +24,21 @@ use Longman\TelegramBot\Exception\TelegramException;
  */
 class InlineKeyboardButtonTest extends TestCase
 {
-    public function testInlineKeyboardButtonNoTextFail()
+    public function testInlineKeyboardButtonNoTextFail(): void
     {
         $this->expectException(TelegramException::class);
         $this->expectExceptionMessage('You must add some text to the button!');
         new InlineKeyboardButton([]);
     }
 
-    public function testInlineKeyboardButtonNoParameterFail()
+    public function testInlineKeyboardButtonNoParameterFail(): void
     {
         $this->expectException(TelegramException::class);
         $this->expectExceptionMessage('You must use only one of these fields: url, login_url, callback_data, switch_inline_query, switch_inline_query_current_chat, callback_game, pay!');
         new InlineKeyboardButton(['text' => 'message']);
     }
 
-    public function testInlineKeyboardButtonTooManyParametersFail()
+    public function testInlineKeyboardButtonTooManyParametersFail(): void
     {
         $this->expectException(TelegramException::class);
         $this->expectExceptionMessage('You must use only one of these fields: url, login_url, callback_data, switch_inline_query, switch_inline_query_current_chat, callback_game, pay!');
@@ -90,7 +90,7 @@ class InlineKeyboardButtonTest extends TestCase
         $test_funcs[array_rand($test_funcs)]();
     }
 
-    public function testInlineKeyboardButtonSuccess()
+    public function testInlineKeyboardButtonSuccess(): void
     {
         new InlineKeyboardButton(['text' => 'message', 'url' => 'url_value']);
         new InlineKeyboardButton(['text' => 'message', 'callback_data' => 'callback_data_value']);
@@ -100,43 +100,43 @@ class InlineKeyboardButtonTest extends TestCase
         new InlineKeyboardButton(['text' => 'message', 'switch_inline_query_current_chat' => '']); // Allow empty string.
         new InlineKeyboardButton(['text' => 'message', 'callback_game' => new CallbackGame([])]);
         new InlineKeyboardButton(['text' => 'message', 'pay' => true]);
-        $this->assertTrue(true);
+        self::assertTrue(true);
     }
 
-    public function testInlineKeyboardButtonCouldBe()
+    public function testInlineKeyboardButtonCouldBe(): void
     {
-        $this->assertTrue(InlineKeyboardButton::couldBe(
+        self::assertTrue(InlineKeyboardButton::couldBe(
             ['text' => 'message', 'url' => 'url_value']
         ));
-        $this->assertTrue(InlineKeyboardButton::couldBe(
+        self::assertTrue(InlineKeyboardButton::couldBe(
             ['text' => 'message', 'callback_data' => 'callback_data_value']
         ));
-        $this->assertTrue(InlineKeyboardButton::couldBe(
+        self::assertTrue(InlineKeyboardButton::couldBe(
             ['text' => 'message', 'switch_inline_query' => 'switch_inline_query_value']
         ));
-        $this->assertTrue(InlineKeyboardButton::couldBe(
+        self::assertTrue(InlineKeyboardButton::couldBe(
             ['text' => 'message', 'switch_inline_query_current_chat' => 'switch_inline_query_current_chat_value']
         ));
-        $this->assertTrue(InlineKeyboardButton::couldBe(
+        self::assertTrue(InlineKeyboardButton::couldBe(
             ['text' => 'message', 'callback_game' => new CallbackGame([])]
         ));
-        $this->assertTrue(InlineKeyboardButton::couldBe(
+        self::assertTrue(InlineKeyboardButton::couldBe(
             ['text' => 'message', 'pay' => true]
         ));
 
-        $this->assertFalse(InlineKeyboardButton::couldBe(['no_text' => 'message']));
-        $this->assertFalse(InlineKeyboardButton::couldBe(['text' => 'message']));
-        $this->assertFalse(InlineKeyboardButton::couldBe(['url' => 'url_value']));
-        $this->assertFalse(InlineKeyboardButton::couldBe(
+        self::assertFalse(InlineKeyboardButton::couldBe(['no_text' => 'message']));
+        self::assertFalse(InlineKeyboardButton::couldBe(['text' => 'message']));
+        self::assertFalse(InlineKeyboardButton::couldBe(['url' => 'url_value']));
+        self::assertFalse(InlineKeyboardButton::couldBe(
             ['callback_data' => 'callback_data_value']
         ));
-        $this->assertFalse(InlineKeyboardButton::couldBe(
+        self::assertFalse(InlineKeyboardButton::couldBe(
             ['switch_inline_query' => 'switch_inline_query_value']
         ));
-        $this->assertFalse(InlineKeyboardButton::couldBe(['callback_game' => new CallbackGame([])]));
-        $this->assertFalse(InlineKeyboardButton::couldBe(['pay' => true]));
+        self::assertFalse(InlineKeyboardButton::couldBe(['callback_game' => new CallbackGame([])]));
+        self::assertFalse(InlineKeyboardButton::couldBe(['pay' => true]));
 
-        $this->assertFalse(InlineKeyboardButton::couldBe([
+        self::assertFalse(InlineKeyboardButton::couldBe([
             'url'                              => 'url_value',
             'callback_data'                    => 'callback_data_value',
             'switch_inline_query'              => 'switch_inline_query_value',
@@ -146,54 +146,54 @@ class InlineKeyboardButtonTest extends TestCase
         ]));
     }
 
-    public function testInlineKeyboardButtonParameterSetting()
+    public function testInlineKeyboardButtonParameterSetting(): void
     {
         $button = new InlineKeyboardButton(['text' => 'message', 'url' => 'url_value']);
-        $this->assertSame('url_value', $button->getUrl());
-        $this->assertEmpty($button->getCallbackData());
-        $this->assertEmpty($button->getSwitchInlineQuery());
-        $this->assertEmpty($button->getSwitchInlineQueryCurrentChat());
-        $this->assertEmpty($button->getCallbackGame());
-        $this->assertEmpty($button->getPay());
+        self::assertSame('url_value', $button->getUrl());
+        self::assertEmpty($button->getCallbackData());
+        self::assertEmpty($button->getSwitchInlineQuery());
+        self::assertEmpty($button->getSwitchInlineQueryCurrentChat());
+        self::assertEmpty($button->getCallbackGame());
+        self::assertEmpty($button->getPay());
 
         $button->setCallbackData('callback_data_value');
-        $this->assertEmpty($button->getUrl());
-        $this->assertSame('callback_data_value', $button->getCallbackData());
-        $this->assertEmpty($button->getSwitchInlineQuery());
-        $this->assertEmpty($button->getSwitchInlineQueryCurrentChat());
-        $this->assertEmpty($button->getCallbackGame());
-        $this->assertEmpty($button->getPay());
+        self::assertEmpty($button->getUrl());
+        self::assertSame('callback_data_value', $button->getCallbackData());
+        self::assertEmpty($button->getSwitchInlineQuery());
+        self::assertEmpty($button->getSwitchInlineQueryCurrentChat());
+        self::assertEmpty($button->getCallbackGame());
+        self::assertEmpty($button->getPay());
 
         $button->setSwitchInlineQuery('switch_inline_query_value');
-        $this->assertEmpty($button->getUrl());
-        $this->assertEmpty($button->getCallbackData());
-        $this->assertSame('switch_inline_query_value', $button->getSwitchInlineQuery());
-        $this->assertEmpty($button->getSwitchInlineQueryCurrentChat());
-        $this->assertEmpty($button->getCallbackGame());
-        $this->assertEmpty($button->getPay());
+        self::assertEmpty($button->getUrl());
+        self::assertEmpty($button->getCallbackData());
+        self::assertSame('switch_inline_query_value', $button->getSwitchInlineQuery());
+        self::assertEmpty($button->getSwitchInlineQueryCurrentChat());
+        self::assertEmpty($button->getCallbackGame());
+        self::assertEmpty($button->getPay());
 
         $button->setSwitchInlineQueryCurrentChat('switch_inline_query_current_chat_value');
-        $this->assertEmpty($button->getUrl());
-        $this->assertEmpty($button->getCallbackData());
-        $this->assertEmpty($button->getSwitchInlineQuery());
-        $this->assertSame('switch_inline_query_current_chat_value', $button->getSwitchInlineQueryCurrentChat());
-        $this->assertEmpty($button->getCallbackGame());
-        $this->assertEmpty($button->getPay());
+        self::assertEmpty($button->getUrl());
+        self::assertEmpty($button->getCallbackData());
+        self::assertEmpty($button->getSwitchInlineQuery());
+        self::assertSame('switch_inline_query_current_chat_value', $button->getSwitchInlineQueryCurrentChat());
+        self::assertEmpty($button->getCallbackGame());
+        self::assertEmpty($button->getPay());
 
         $button->setCallbackGame($callback_game = new CallbackGame([]));
-        $this->assertEmpty($button->getUrl());
-        $this->assertEmpty($button->getCallbackData());
-        $this->assertEmpty($button->getSwitchInlineQuery());
-        $this->assertEmpty($button->getSwitchInlineQueryCurrentChat());
-        $this->assertSame($callback_game, $button->getCallbackGame());
-        $this->assertEmpty($button->getPay());
+        self::assertEmpty($button->getUrl());
+        self::assertEmpty($button->getCallbackData());
+        self::assertEmpty($button->getSwitchInlineQuery());
+        self::assertEmpty($button->getSwitchInlineQueryCurrentChat());
+        self::assertSame($callback_game, $button->getCallbackGame());
+        self::assertEmpty($button->getPay());
 
         $button->setPay(true);
-        $this->assertEmpty($button->getUrl());
-        $this->assertEmpty($button->getCallbackData());
-        $this->assertEmpty($button->getSwitchInlineQuery());
-        $this->assertEmpty($button->getSwitchInlineQueryCurrentChat());
-        $this->assertEmpty($button->getCallbackGame());
-        $this->assertTrue($button->getPay());
+        self::assertEmpty($button->getUrl());
+        self::assertEmpty($button->getCallbackData());
+        self::assertEmpty($button->getSwitchInlineQuery());
+        self::assertEmpty($button->getSwitchInlineQueryCurrentChat());
+        self::assertEmpty($button->getCallbackGame());
+        self::assertTrue($button->getPay());
     }
 }

--- a/tests/Unit/Entities/InlineKeyboardTest.php
+++ b/tests/Unit/Entities/InlineKeyboardTest.php
@@ -24,7 +24,7 @@ use Longman\TelegramBot\Exception\TelegramException;
  */
 class InlineKeyboardTest extends TestCase
 {
-    private function getRandomButton($text)
+    private function getRandomButton($text): InlineKeyboardButton
     {
         $random_params = ['url', 'callback_data', 'switch_inline_query', 'switch_inline_query_current_chat', 'pay'];
         $param         = $random_params[array_rand($random_params, 1)];
@@ -36,21 +36,21 @@ class InlineKeyboardTest extends TestCase
         return new InlineKeyboardButton($data);
     }
 
-    public function testInlineKeyboardDataMalformedField()
+    public function testInlineKeyboardDataMalformedField(): void
     {
         $this->expectException(TelegramException::class);
         $this->expectExceptionMessage('inline_keyboard field is not an array!');
         new InlineKeyboard(['inline_keyboard' => 'wrong']);
     }
 
-    public function testInlineKeyboardDataMalformedSubfield()
+    public function testInlineKeyboardDataMalformedSubfield(): void
     {
         $this->expectException(TelegramException::class);
         $this->expectExceptionMessage('inline_keyboard subfield is not an array!');
         new InlineKeyboard(['inline_keyboard' => ['wrong']]);
     }
 
-    public function testInlineKeyboardSingleButtonSingleRow()
+    public function testInlineKeyboardSingleButtonSingleRow(): void
     {
         $inline_keyboard = (new InlineKeyboard(
             $this->getRandomButton('Button Text 1')
@@ -63,7 +63,7 @@ class InlineKeyboardTest extends TestCase
         self::assertSame('Button Text 2', $inline_keyboard[0][0]->getText());
     }
 
-    public function testInlineKeyboardSingleButtonMultipleRows()
+    public function testInlineKeyboardSingleButtonMultipleRows(): void
     {
         $keyboard = (new InlineKeyboard(
             $this->getRandomButton('Button Text 1'),
@@ -84,7 +84,7 @@ class InlineKeyboardTest extends TestCase
         self::assertSame('Button Text 6', $keyboard[2][0]->getText());
     }
 
-    public function testInlineKeyboardMultipleButtonsSingleRow()
+    public function testInlineKeyboardMultipleButtonsSingleRow(): void
     {
         $keyboard = (new InlineKeyboard([
             $this->getRandomButton('Button Text 1'),
@@ -94,7 +94,7 @@ class InlineKeyboardTest extends TestCase
         self::assertSame('Button Text 2', $keyboard[0][1]->getText());
     }
 
-    public function testInlineKeyboardMultipleButtonsMultipleRows()
+    public function testInlineKeyboardMultipleButtonsMultipleRows(): void
     {
         $keyboard = (new InlineKeyboard(
             [
@@ -113,7 +113,7 @@ class InlineKeyboardTest extends TestCase
         self::assertSame('Button Text 4', $keyboard[1][1]->getText());
     }
 
-    public function testInlineKeyboardAddRows()
+    public function testInlineKeyboardAddRows(): void
     {
         $keyboard_obj = new InlineKeyboard([]);
 

--- a/tests/Unit/Entities/KeyboardButtonTest.php
+++ b/tests/Unit/Entities/KeyboardButtonTest.php
@@ -24,59 +24,59 @@ use Longman\TelegramBot\Exception\TelegramException;
  */
 class KeyboardButtonTest extends TestCase
 {
-    public function testKeyboardButtonNoTextFail()
+    public function testKeyboardButtonNoTextFail(): void
     {
         $this->expectException(TelegramException::class);
         $this->expectExceptionMessage('You must add some text to the button!');
         new KeyboardButton([]);
     }
 
-    public function testKeyboardButtonTooManyParametersFail()
+    public function testKeyboardButtonTooManyParametersFail(): void
     {
         $this->expectException(TelegramException::class);
         $this->expectExceptionMessage('You must use only one of these fields: request_contact, request_location, request_poll!');
         new KeyboardButton(['text' => 'message', 'request_contact' => true, 'request_location' => true]);
     }
 
-    public function testKeyboardButtonSuccess()
+    public function testKeyboardButtonSuccess(): void
     {
         new KeyboardButton(['text' => 'message']);
         new KeyboardButton(['text' => 'message', 'request_contact' => true]);
         new KeyboardButton(['text' => 'message', 'request_location' => true]);
         new KeyboardButton(['text' => 'message', 'request_poll' => new KeyboardButtonPollType([])]);
-        $this->assertTrue(true);
+        self::assertTrue(true);
     }
 
-    public function testInlineKeyboardButtonCouldBe()
+    public function testInlineKeyboardButtonCouldBe(): void
     {
-        $this->assertTrue(KeyboardButton::couldBe(['text' => 'message']));
-        $this->assertFalse(KeyboardButton::couldBe(['no_text' => 'message']));
+        self::assertTrue(KeyboardButton::couldBe(['text' => 'message']));
+        self::assertFalse(KeyboardButton::couldBe(['no_text' => 'message']));
     }
 
-    public function testKeyboardButtonParameterSetting()
+    public function testKeyboardButtonParameterSetting(): void
     {
         $button = new KeyboardButton('message');
-        $this->assertSame('message', $button->getText());
-        $this->assertEmpty($button->getRequestContact());
-        $this->assertEmpty($button->getRequestLocation());
-        $this->assertEmpty($button->getRequestPoll());
+        self::assertSame('message', $button->getText());
+        self::assertEmpty($button->getRequestContact());
+        self::assertEmpty($button->getRequestLocation());
+        self::assertEmpty($button->getRequestPoll());
 
         $button->setText('new message');
-        $this->assertSame('new message', $button->getText());
+        self::assertSame('new message', $button->getText());
 
         $button->setRequestContact(true);
-        $this->assertTrue($button->getRequestContact());
-        $this->assertEmpty($button->getRequestLocation());
-        $this->assertEmpty($button->getRequestPoll());
+        self::assertTrue($button->getRequestContact());
+        self::assertEmpty($button->getRequestLocation());
+        self::assertEmpty($button->getRequestPoll());
 
         $button->setRequestLocation(true);
-        $this->assertEmpty($button->getRequestContact());
-        $this->assertTrue($button->getRequestLocation());
-        $this->assertEmpty($button->getRequestPoll());
+        self::assertEmpty($button->getRequestContact());
+        self::assertTrue($button->getRequestLocation());
+        self::assertEmpty($button->getRequestPoll());
 
         $button->setRequestPoll(new KeyboardButtonPollType([]));
-        $this->assertEmpty($button->getRequestContact());
-        $this->assertEmpty($button->getRequestLocation());
-        $this->assertInstanceOf(KeyboardButtonPollType::class, $button->getRequestPoll());
+        self::assertEmpty($button->getRequestContact());
+        self::assertEmpty($button->getRequestLocation());
+        self::assertInstanceOf(KeyboardButtonPollType::class, $button->getRequestPoll());
     }
 }

--- a/tests/Unit/Entities/KeyboardTest.php
+++ b/tests/Unit/Entities/KeyboardTest.php
@@ -24,21 +24,21 @@ use Longman\TelegramBot\Exception\TelegramException;
  */
 class KeyboardTest extends TestCase
 {
-    public function testKeyboardDataMalformedField()
+    public function testKeyboardDataMalformedField(): void
     {
         $this->expectException(TelegramException::class);
         $this->expectExceptionMessage('keyboard field is not an array!');
         new Keyboard(['keyboard' => 'wrong']);
     }
 
-    public function testKeyboardDataMalformedSubfield()
+    public function testKeyboardDataMalformedSubfield(): void
     {
         $this->expectException(TelegramException::class);
         $this->expectExceptionMessage('keyboard subfield is not an array!');
         new Keyboard(['keyboard' => ['wrong']]);
     }
 
-    public function testKeyboardSingleButtonSingleRow()
+    public function testKeyboardSingleButtonSingleRow(): void
     {
         $keyboard = (new Keyboard('Button Text 1'))->getProperty('keyboard');
         self::assertSame('Button Text 1', $keyboard[0][0]->getText());
@@ -47,7 +47,7 @@ class KeyboardTest extends TestCase
         self::assertSame('Button Text 2', $keyboard[0][0]->getText());
     }
 
-    public function testKeyboardSingleButtonMultipleRows()
+    public function testKeyboardSingleButtonMultipleRows(): void
     {
         $keyboard = (new Keyboard(
             'Button Text 1',
@@ -68,14 +68,14 @@ class KeyboardTest extends TestCase
         self::assertSame('Button Text 6', $keyboard[2][0]->getText());
     }
 
-    public function testKeyboardMultipleButtonsSingleRow()
+    public function testKeyboardMultipleButtonsSingleRow(): void
     {
         $keyboard = (new Keyboard(['Button Text 1', 'Button Text 2']))->getProperty('keyboard');
         self::assertSame('Button Text 1', $keyboard[0][0]->getText());
         self::assertSame('Button Text 2', $keyboard[0][1]->getText());
     }
 
-    public function testKeyboardMultipleButtonsMultipleRows()
+    public function testKeyboardMultipleButtonsMultipleRows(): void
     {
         $keyboard = (new Keyboard(
             ['Button Text 1', 'Button Text 2'],
@@ -88,7 +88,7 @@ class KeyboardTest extends TestCase
         self::assertSame('Button Text 4', $keyboard[1][1]->getText());
     }
 
-    public function testKeyboardWithButtonObjects()
+    public function testKeyboardWithButtonObjects(): void
     {
         $keyboard = (new Keyboard(
             new KeyboardButton('Button Text 1')
@@ -111,7 +111,7 @@ class KeyboardTest extends TestCase
         self::assertSame('Button Text 6', $keyboard[1][1]->getText());
     }
 
-    public function testKeyboardWithDataArray()
+    public function testKeyboardWithDataArray(): void
     {
         $resize_keyboard   = (bool) mt_rand(0, 1);
         $one_time_keyboard = (bool) mt_rand(0, 1);
@@ -132,7 +132,7 @@ class KeyboardTest extends TestCase
         self::assertSame($selective, $keyboard_obj->getSelective());
     }
 
-    public function testPredefinedKeyboards()
+    public function testPredefinedKeyboards(): void
     {
         $keyboard_remove = Keyboard::remove();
         self::assertTrue($keyboard_remove->getProperty('remove_keyboard'));
@@ -141,7 +141,7 @@ class KeyboardTest extends TestCase
         self::assertTrue($keyboard_force_reply->getProperty('force_reply'));
     }
 
-    public function testKeyboardMethods()
+    public function testKeyboardMethods(): void
     {
         $keyboard_obj = new Keyboard([]);
 
@@ -165,7 +165,7 @@ class KeyboardTest extends TestCase
         self::assertFalse($keyboard_obj->getSelective());
     }
 
-    public function testKeyboardAddRows()
+    public function testKeyboardAddRows(): void
     {
         $keyboard_obj = new Keyboard([]);
 

--- a/tests/Unit/Entities/LocationTest.php
+++ b/tests/Unit/Entities/LocationTest.php
@@ -32,25 +32,25 @@ class LocationTest extends TestCase
         ];
     }
 
-    public function testBaseStageLocation()
+    public function testBaseStageLocation(): void
     {
         $location = new Location($this->coordinates);
-        $this->assertInstanceOf(Location::class, $location);
+        self::assertInstanceOf(Location::class, $location);
     }
 
-    public function testGetLongitude()
+    public function testGetLongitude(): void
     {
         $location = new Location($this->coordinates);
         $long     = $location->getLongitude();
-        $this->assertIsFloat($long);
-        $this->assertEquals($this->coordinates['longitude'], $long);
+        self::assertIsFloat($long);
+        self::assertEquals($this->coordinates['longitude'], $long);
     }
 
-    public function testGetLatitude()
+    public function testGetLatitude(): void
     {
         $location = new Location($this->coordinates);
         $lat      = $location->getLatitude();
-        $this->assertIsFloat($lat);
-        $this->assertEquals($this->coordinates['latitude'], $lat);
+        self::assertIsFloat($lat);
+        self::assertEquals($this->coordinates['latitude'], $lat);
     }
 }

--- a/tests/Unit/Entities/MessageTest.php
+++ b/tests/Unit/Entities/MessageTest.php
@@ -20,7 +20,7 @@ namespace Longman\TelegramBot\Tests\Unit;
  */
 class MessageTest extends TestCase
 {
-    public function testTextAndCommandRecognise()
+    public function testTextAndCommandRecognise(): void
     {
         // /command
         $message = TestHelpers::getFakeMessageObject(['text' => '/help']);
@@ -43,7 +43,7 @@ class MessageTest extends TestCase
         self::assertEquals('/help@testbot', $message->getText());
         self::assertEquals('', $message->getText(true));
 
-        // /commmad text
+        // /command text
         $message = TestHelpers::getFakeMessageObject(['text' => '/help some text']);
         self::assertEquals('/help', $message->getFullCommand());
         self::assertEquals('help', $message->getCommand());
@@ -57,7 +57,7 @@ class MessageTest extends TestCase
         self::assertEquals('/help@testbot some text', $message->getText());
         self::assertEquals('some text', $message->getText(true));
 
-        // /commmad\n text
+        // /command\n text
         $message = TestHelpers::getFakeMessageObject(['text' => "/help\n some text"]);
         self::assertEquals('/help', $message->getFullCommand());
         self::assertEquals('help', $message->getCommand());
@@ -79,7 +79,7 @@ class MessageTest extends TestCase
         self::assertEquals("\nsome text", $message->getText(true));
     }
 
-    public function testGetType()
+    public function testGetType(): void
     {
         $message = TestHelpers::getFakeMessageObject(['text' => null]);
         self::assertSame('message', $message->getType());

--- a/tests/Unit/Entities/ReplyToMessageTest.php
+++ b/tests/Unit/Entities/ReplyToMessageTest.php
@@ -22,7 +22,7 @@ use Longman\TelegramBot\Entities\Update;
  */
 class ReplyToMessageTest extends TestCase
 {
-    public function testChatType()
+    public function testChatType(): void
     {
         $json = '{
             "update_id":137809335,

--- a/tests/Unit/Entities/ServerResponseTest.php
+++ b/tests/Unit/Entities/ServerResponseTest.php
@@ -35,10 +35,10 @@ class ServerResponseTest extends TestCase
     protected function setUp(): void
     {
         // Make sure the current action in the Request class is unset.
-        TestHelpers::setStaticProperty(Request::class, 'current_action', null);
+        TestHelpers::setStaticProperty(Request::class, 'current_action', '');
     }
 
-    public function sendMessageOk()
+    public function sendMessageOk(): string
     {
         return '{
             "ok":true,
@@ -52,7 +52,7 @@ class ServerResponseTest extends TestCase
         }';
     }
 
-    public function testSendMessageOk()
+    public function testSendMessageOk(): void
     {
         $result        = $this->sendMessageOk();
         $server        = new ServerResponse(json_decode($result, true), 'testbot');
@@ -77,7 +77,7 @@ class ServerResponseTest extends TestCase
         //... they are not finished...
     }
 
-    public function sendMessageFail()
+    public function sendMessageFail(): string
     {
         return '{
             "ok":false,
@@ -86,7 +86,7 @@ class ServerResponseTest extends TestCase
         }';
     }
 
-    public function testSendMessageFail()
+    public function testSendMessageFail(): void
     {
         $result = $this->sendMessageFail();
         $server = new ServerResponse(json_decode($result, true), 'testbot');
@@ -97,12 +97,12 @@ class ServerResponseTest extends TestCase
         self::assertEquals('Error: Bad Request: wrong chat id', $server->getDescription());
     }
 
-    public function setWebhookOk()
+    public function setWebhookOk(): string
     {
         return '{"ok":true,"result":true,"description":"Webhook was set"}';
     }
 
-    public function testSetWebhookOk()
+    public function testSetWebhookOk(): void
     {
         $result = $this->setWebhookOk();
         $server = new ServerResponse(json_decode($result, true), 'testbot');
@@ -113,16 +113,16 @@ class ServerResponseTest extends TestCase
         self::assertEquals('Webhook was set', $server->getDescription());
     }
 
-    public function setWebhookFail()
+    public function setWebhookFail(): string
     {
         return '{
             "ok":false,
             "error_code":400,
-            "description":"Error: Bad request: htttps:\/\/domain.host.org\/dir\/hook.php"
+            "description":"Error: Bad request: https:\/\/domain.host.org\/dir\/hook.php"
         }';
     }
 
-    public function testSetWebhookFail()
+    public function testSetWebhookFail(): void
     {
         $result = $this->setWebhookFail();
         $server = new ServerResponse(json_decode($result, true), 'testbot');
@@ -130,10 +130,10 @@ class ServerResponseTest extends TestCase
         self::assertFalse($server->isOk());
         self::assertNull($server->getResult());
         self::assertEquals(400, $server->getErrorCode());
-        self::assertEquals('Error: Bad request: htttps://domain.host.org/dir/hook.php', $server->getDescription());
+        self::assertEquals('Error: Bad request: https://domain.host.org/dir/hook.php', $server->getDescription());
     }
 
-    public function getUpdatesArray()
+    public function getUpdatesArray(): string
     {
         return '{
             "ok":true,
@@ -182,7 +182,7 @@ class ServerResponseTest extends TestCase
         }';
     }
 
-    public function testGetUpdatesArray()
+    public function testGetUpdatesArray(): void
     {
         $result = $this->getUpdatesArray();
         $server = new ServerResponse(json_decode($result, true), 'testbot');
@@ -191,12 +191,12 @@ class ServerResponseTest extends TestCase
         self::assertInstanceOf(Update::class, $server->getResult()[0]);
     }
 
-    public function getUpdatesEmpty()
+    public function getUpdatesEmpty(): string
     {
         return '{"ok":true,"result":[]}';
     }
 
-    public function testGetUpdatesEmpty()
+    public function testGetUpdatesEmpty(): void
     {
         $result = $this->getUpdatesEmpty();
         $server = new ServerResponse(json_decode($result, true), 'testbot');
@@ -204,7 +204,7 @@ class ServerResponseTest extends TestCase
         self::assertEmpty($server->getResult());
     }
 
-    public function getUserProfilePhotos()
+    public function getUserProfilePhotos(): string
     {
         TestHelpers::setStaticProperty(Request::class, 'current_action', 'getUserProfilePhotos');
         return '{
@@ -232,7 +232,7 @@ class ServerResponseTest extends TestCase
         }';
     }
 
-    public function testGetUserProfilePhotos()
+    public function testGetUserProfilePhotos(): void
     {
         $result        = $this->getUserProfilePhotos();
         $server        = new ServerResponse(json_decode($result, true), 'testbot');
@@ -250,7 +250,7 @@ class ServerResponseTest extends TestCase
         self::assertInstanceOf(PhotoSize::class, $photos[0][0]);
     }
 
-    public function getFile()
+    public function getFile(): string
     {
         TestHelpers::setStaticProperty(Request::class, 'current_action', 'getFile');
         return '{
@@ -263,7 +263,7 @@ class ServerResponseTest extends TestCase
         }';
     }
 
-    public function testGetFile()
+    public function testGetFile(): void
     {
         $result = $this->getFile();
         $server = new ServerResponse(json_decode($result, true), 'testbot');
@@ -271,7 +271,7 @@ class ServerResponseTest extends TestCase
         self::assertInstanceOf(File::class, $server->getResult());
     }
 
-    public function testSetGeneralTestFakeResponse()
+    public function testSetGeneralTestFakeResponse(): void
     {
         //setWebhook ok
         $fake_response = Request::generateGeneralFakeServerResponse();
@@ -314,7 +314,7 @@ class ServerResponseTest extends TestCase
         //... they are not finished...
     }
 
-    public function getStickerSet()
+    public function getStickerSet(): string
     {
         TestHelpers::setStaticProperty(Request::class, 'current_action', 'getStickerSet');
         return '{
@@ -365,7 +365,7 @@ class ServerResponseTest extends TestCase
         }';
     }
 
-    public function testGetStickerSet()
+    public function testGetStickerSet(): void
     {
         $result = $this->getStickerSet();
         $server = new ServerResponse(json_decode($result, true), 'testbot');

--- a/tests/Unit/Entities/UpdateTest.php
+++ b/tests/Unit/Entities/UpdateTest.php
@@ -22,7 +22,7 @@ use Longman\TelegramBot\Entities\Update;
  */
 class UpdateTest extends TestCase
 {
-    public function testUpdateCast()
+    public function testUpdateCast(): void
     {
         $json = '{
             "update_id":137809336,

--- a/tests/Unit/Entities/UserTest.php
+++ b/tests/Unit/Entities/UserTest.php
@@ -22,19 +22,19 @@ use Longman\TelegramBot\Entities\User;
  */
 class UserTest extends TestCase
 {
-    public function testInstance()
+    public function testInstance(): void
     {
         $user = new User(['id' => 1]);
         self::assertInstanceOf(User::class, $user);
     }
 
-    public function testGetId()
+    public function testGetId(): void
     {
         $user = new User(['id' => 123]);
         self::assertEquals(123, $user->getId());
     }
 
-    public function testTryMention()
+    public function testTryMention(): void
     {
         // Username
         $user = new User(['id' => 1, 'first_name' => 'John', 'last_name' => 'Taylor', 'username' => 'jtaylor']);
@@ -49,7 +49,7 @@ class UserTest extends TestCase
         self::assertEquals('John Taylor', $user->tryMention());
     }
 
-    public function testEscapeMarkdown()
+    public function testEscapeMarkdown(): void
     {
         // Username.
         $user = new User(['id' => 1, 'first_name' => 'John', 'last_name' => 'Taylor', 'username' => 'j_taylor']);
@@ -67,7 +67,7 @@ class UserTest extends TestCase
         self::assertEquals('John \`Taylor\`', $user->tryMention(true));
     }
 
-    public function testGetProperties()
+    public function testGetProperties(): void
     {
         // Username.
         $user = new User(['id' => 1, 'username' => 'name_phpunit']);

--- a/tests/Unit/Entities/WebhookInfoTest.php
+++ b/tests/Unit/Entities/WebhookInfoTest.php
@@ -40,91 +40,91 @@ class WebhookInfoTest extends TestCase
         ];
     }
 
-    public function testBaseStageWebhookInfo()
+    public function testBaseStageWebhookInfo(): void
     {
         $webhook = new WebhookInfo($this->data);
-        $this->assertInstanceOf(WebhookInfo::class, $webhook);
+        self::assertInstanceOf(WebhookInfo::class, $webhook);
     }
 
-    public function testGetUrl()
+    public function testGetUrl(): void
     {
         $webhook = new WebhookInfo($this->data);
         $url     = $webhook->getUrl();
-        $this->assertEquals($this->data['url'], $url);
+        self::assertEquals($this->data['url'], $url);
     }
 
-    public function testGetHasCustomCertificate()
+    public function testGetHasCustomCertificate(): void
     {
         $webhook            = new WebhookInfo($this->data);
         $custom_certificate = $webhook->getHasCustomCertificate();
-        $this->assertIsBool($custom_certificate);
-        $this->assertEquals($this->data['has_custom_certificate'], $custom_certificate);
+        self::assertIsBool($custom_certificate);
+        self::assertEquals($this->data['has_custom_certificate'], $custom_certificate);
     }
 
-    public function testGetPendingUpdateCount()
+    public function testGetPendingUpdateCount(): void
     {
         $webhook      = new WebhookInfo($this->data);
         $update_count = $webhook->getPendingUpdateCount();
-        $this->assertIsInt($update_count);
-        $this->assertEquals($this->data['pending_update_count'], $update_count);
+        self::assertIsInt($update_count);
+        self::assertEquals($this->data['pending_update_count'], $update_count);
     }
 
-    public function testGetLastErrorDate()
+    public function testGetLastErrorDate(): void
     {
         $webhook    = new WebhookInfo($this->data);
         $error_date = $webhook->getLastErrorDate();
-        $this->assertIsInt($error_date);
-        $this->assertEquals($this->data['last_error_date'], $error_date);
+        self::assertIsInt($error_date);
+        self::assertEquals($this->data['last_error_date'], $error_date);
     }
 
-    public function testGetLastErrorMessage()
+    public function testGetLastErrorMessage(): void
     {
         $webhook   = new WebhookInfo($this->data);
         $error_msg = $webhook->getLastErrorMessage();
-        $this->assertIsString($error_msg);
-        $this->assertEquals($this->data['last_error_message'], $error_msg);
+        self::assertIsString($error_msg);
+        self::assertEquals($this->data['last_error_message'], $error_msg);
     }
 
-    public function testGetMaxConnections()
+    public function testGetMaxConnections(): void
     {
         $webhook         = new WebhookInfo($this->data);
         $max_connections = $webhook->getMaxConnections();
-        $this->assertIsInt($max_connections);
-        $this->assertEquals($this->data['max_connections'], $max_connections);
+        self::assertIsInt($max_connections);
+        self::assertEquals($this->data['max_connections'], $max_connections);
     }
 
-    public function testGetAllowedUpdates()
+    public function testGetAllowedUpdates(): void
     {
         $webhook         = new WebhookInfo($this->data);
         $allowed_updates = $webhook->getAllowedUpdates();
-        $this->assertIsArray($allowed_updates);
-        $this->assertEquals($this->data['allowed_updates'], $allowed_updates);
+        self::assertIsArray($allowed_updates);
+        self::assertEquals($this->data['allowed_updates'], $allowed_updates);
     }
 
-    public function testGetDataWithoutParams()
+    public function testGetDataWithoutParams(): void
     {
         // Make a copy to not risk failed tests if not run in proper order.
         $data = $this->data;
 
         unset($data['url']);
-        $this->assertNull((new WebhookInfo($data))->getUrl());
+        self::assertNull((new WebhookInfo($data))->getUrl());
 
         unset($data['has_custom_certificate']);
-        $this->assertNull((new WebhookInfo($data))->getHasCustomCertificate());
+        self::assertNull((new WebhookInfo($data))->getHasCustomCertificate());
 
         unset($data['pending_update_count']);
-        $this->assertNull((new WebhookInfo($data))->getPendingUpdateCount());
+        self::assertNull((new WebhookInfo($data))->getPendingUpdateCount());
 
         unset($data['last_error_date']);
-        $this->assertNull((new WebhookInfo($data))->getLastErrorDate());
+        self::assertNull((new WebhookInfo($data))->getLastErrorDate());
 
         unset($data['last_error_message']);
-        $this->assertNull((new WebhookInfo($data))->getLastErrorMessage());
+        self::assertNull((new WebhookInfo($data))->getLastErrorMessage());
 
         unset($data['max_connections']);
-        $this->assertNull((new WebhookInfo($data))->getMaxConnections());
+        self::assertNull((new WebhookInfo($data))->getMaxConnections());
 
         unset($data['allowed_updates']);
-        $this->assertNull((new WebhookInfo($data))->getAllowedUpdates());
+        self::assertNull((new WebhookInfo($data))->getAllowedUpdates());
     }
 }

--- a/tests/Unit/TelegramLogTest.php
+++ b/tests/Unit/TelegramLogTest.php
@@ -59,7 +59,7 @@ class TelegramLogTest extends TestCase
         }
     }
 
-    public function testNullLogger()
+    public function testNullLogger(): void
     {
         TelegramLog::initialize(null, null);
 
@@ -68,49 +68,49 @@ class TelegramLogTest extends TestCase
         TelegramLog::update('my update log');
 
         foreach (self::$logfiles as $file) {
-            $this->assertFileNotExists($file);
+            self::assertFileNotExists($file);
         }
     }
 
-    public function testDebugStream()
+    public function testDebugStream(): void
     {
         $file = self::$logfiles['debug'];
 
-        $this->assertFileNotExists($file);
+        self::assertFileNotExists($file);
         TelegramLog::debug('my debug log');
         TelegramLog::debug('my {place} {holder} debug log', ['place' => 'custom', 'holder' => 'placeholder']);
 
-        $this->assertFileExists($file);
+        self::assertFileExists($file);
         $debug_log = file_get_contents($file);
-        $this->assertStringContainsString('bot_log.DEBUG: my debug log', $debug_log);
-        $this->assertStringContainsString('bot_log.DEBUG: my custom placeholder debug log', $debug_log);
+        self::assertStringContainsString('bot_log.DEBUG: my debug log', $debug_log);
+        self::assertStringContainsString('bot_log.DEBUG: my custom placeholder debug log', $debug_log);
     }
 
-    public function testErrorStream()
+    public function testErrorStream(): void
     {
         $file = self::$logfiles['error'];
 
-        $this->assertFileNotExists($file);
+        self::assertFileNotExists($file);
         TelegramLog::error('my error log');
         TelegramLog::error('my {place} {holder} error log', ['place' => 'custom', 'holder' => 'placeholder']);
 
-        $this->assertFileExists($file);
+        self::assertFileExists($file);
         $error_log = file_get_contents($file);
-        $this->assertStringContainsString('bot_log.ERROR: my error log', $error_log);
-        $this->assertStringContainsString('bot_log.ERROR: my custom placeholder error log', $error_log);
+        self::assertStringContainsString('bot_log.ERROR: my error log', $error_log);
+        self::assertStringContainsString('bot_log.ERROR: my custom placeholder error log', $error_log);
     }
 
-    public function testUpdateStream()
+    public function testUpdateStream(): void
     {
         $file = self::$logfiles['update'];
 
-        $this->assertFileNotExists($file);
+        self::assertFileNotExists($file);
         TelegramLog::update('my update log');
         TelegramLog::update('my {place} {holder} update log', ['place' => 'custom', 'holder' => 'placeholder']);
 
-        $this->assertFileExists($file);
+        self::assertFileExists($file);
         $update_log = file_get_contents($file);
-        $this->assertStringContainsString('my update log', $update_log);
-        $this->assertStringContainsString('my custom placeholder update log', $update_log);
+        self::assertStringContainsString('my update log', $update_log);
+        self::assertStringContainsString('my custom placeholder update log', $update_log);
     }
 }

--- a/tests/Unit/TelegramTest.php
+++ b/tests/Unit/TelegramTest.php
@@ -60,95 +60,87 @@ class TelegramTest extends TestCase
         }
     }
 
-    public function testNewInstanceWithoutApiKeyParam()
+    public function testNewInstanceWithoutApiKeyParam(): void
     {
         $this->expectException(TelegramException::class);
         $this->expectExceptionMessage('API KEY not defined!');
-        new Telegram(null, 'testbot');
+        new Telegram('');
     }
 
-    public function testNewInstanceWithInvalidApiKeyParam()
+    public function testNewInstanceWithInvalidApiKeyParam(): void
     {
         $this->expectException(TelegramException::class);
         $this->expectExceptionMessage('Invalid API KEY defined!');
-        new Telegram('invalid-api-key-format', null);
+        new Telegram('invalid-api-key-format');
     }
 
-    public function testGetApiKey()
+    public function testGetApiKey(): void
     {
-        $this->assertEquals(self::$dummy_api_key, $this->telegram->getApiKey());
+        self::assertEquals(self::$dummy_api_key, $this->telegram->getApiKey());
     }
 
-    public function testGetBotUsername()
+    public function testGetBotUsername(): void
     {
-        $this->assertEquals('testbot', $this->telegram->getBotUsername());
+        self::assertEquals('testbot', $this->telegram->getBotUsername());
     }
 
-    public function testEnableAdmins()
+    public function testEnableAdmins(): void
     {
         $tg = $this->telegram;
 
-        $this->assertEmpty($tg->getAdminList());
+        self::assertEmpty($tg->getAdminList());
 
         // Single
         $tg->enableAdmin(1);
-        $this->assertCount(1, $tg->getAdminList());
+        self::assertCount(1, $tg->getAdminList());
 
         // Multiple
         $tg->enableAdmins([2, 3]);
-        $this->assertCount(3, $tg->getAdminList());
+        self::assertCount(3, $tg->getAdminList());
 
         // Already added
         $tg->enableAdmin(2);
-        $this->assertCount(3, $tg->getAdminList());
-
-        // Integer as a string
-        $tg->enableAdmin('4');
-        $this->assertCount(3, $tg->getAdminList());
-
-        // Random string
-        $tg->enableAdmin('a string?');
-        $this->assertCount(3, $tg->getAdminList());
+        self::assertCount(3, $tg->getAdminList());
     }
 
-    public function testAddCustomCommandsPaths()
+    public function testAddCustomCommandsPaths(): void
     {
         $tg = $this->telegram;
 
-        $this->assertCount(1, $tg->getCommandsPaths());
+        self::assertCount(1, $tg->getCommandsPaths());
 
         $tg->addCommandsPath($this->custom_commands_paths[0]);
-        $this->assertCount(2, $tg->getCommandsPaths());
-        $this->assertArraySubset(
+        self::assertCount(2, $tg->getCommandsPaths());
+        self::assertArraySubset(
             [$this->custom_commands_paths[0]],
             $tg->getCommandsPaths()
         );
 
         $tg->addCommandsPath('/invalid/path');
-        $this->assertCount(2, $tg->getCommandsPaths());
+        self::assertCount(2, $tg->getCommandsPaths());
 
         $tg->addCommandsPaths([
             $this->custom_commands_paths[1],
             $this->custom_commands_paths[2],
         ]);
-        $this->assertCount(4, $tg->getCommandsPaths());
-        $this->assertArraySubset(
+        self::assertCount(4, $tg->getCommandsPaths());
+        self::assertArraySubset(
             array_reverse($this->custom_commands_paths),
             $tg->getCommandsPaths()
         );
 
         $tg->addCommandsPath($this->custom_commands_paths[0]);
-        $this->assertCount(4, $tg->getCommandsPaths());
+        self::assertCount(4, $tg->getCommandsPaths());
     }
 
-    public function testGetCommandsList()
+    public function testGetCommandsList(): void
     {
         $commands = $this->telegram->getCommandsList();
-        $this->assertIsArray($commands);
-        $this->assertNotCount(0, $commands);
+        self::assertIsArray($commands);
+        self::assertNotCount(0, $commands);
     }
 
-    public function testUpdateFilter()
+    public function testUpdateFilter(): void
     {
         $rawUpdate = '{
             "update_id": 513400512,
@@ -188,11 +180,11 @@ class TelegramTest extends TestCase
             return true;
         });
         $response = $this->telegram->processUpdate($update);
-        $this->assertFalse($response->isOk());
+        self::assertFalse($response->isOk());
 
         // Check that the reason is written to the debug log.
         $debug_log = file_get_contents($debug_log_file);
-        $this->assertStringContainsString('Invalid user, update denied.', $debug_log);
+        self::assertStringContainsString('Invalid user, update denied.', $debug_log);
         file_exists($debug_log_file) && unlink($debug_log_file);
     }
 }

--- a/tests/Unit/TestCase.php
+++ b/tests/Unit/TestCase.php
@@ -20,10 +20,10 @@ class TestCase extends BaseTestCase
      */
     public static $dummy_api_key = '123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11';
 
-    protected function skip64BitTest()
+    protected function skip64BitTest(): void
     {
         if (PHP_INT_SIZE === 4) {
-            $this->markTestSkipped(
+            self::markTestSkipped(
                 'Skipping test that can run only on a 64-bit build of PHP.'
             );
         }

--- a/tests/Unit/TestHelpers.php
+++ b/tests/Unit/TestHelpers.php
@@ -58,8 +58,10 @@ class TestHelpers
      * @param object $object   Object that contains the property
      * @param string $property Name of the property who's value we want to set
      * @param mixed  $value    The value to set to the property
+     *
+     * @throws \ReflectionException
      */
-    public static function setObjectProperty($object, $property, $value)
+    public static function setObjectProperty(object $object, string $property, $value): void
     {
         $ref_object   = new \ReflectionObject($object);
         $ref_property = $ref_object->getProperty($property);
@@ -73,8 +75,10 @@ class TestHelpers
      * @param string $class    Class that contains the static property
      * @param string $property Name of the property who's value we want to set
      * @param mixed  $value    The value to set to the property
+     *
+     * @throws \ReflectionException
      */
-    public static function setStaticProperty($class, $property, $value)
+    public static function setStaticProperty(string $class, string $property, $value): void
     {
         $ref_property = new \ReflectionProperty($class, $property);
         $ref_property->setAccessible(true);
@@ -88,7 +92,7 @@ class TestHelpers
      *
      * @return Update
      */
-    public static function getFakeUpdateObject($data = null)
+    public static function getFakeUpdateObject(array $data = []): Update
     {
         $data = $data ?: [
             'update_id' => mt_rand(),
@@ -110,7 +114,7 @@ class TestHelpers
      *
      * @return Update
      */
-    public static function getFakeUpdateCommandObject($command_text)
+    public static function getFakeUpdateCommandObject(string $command_text): Update
     {
         $data = [
             'update_id' => mt_rand(),
@@ -132,7 +136,7 @@ class TestHelpers
      *
      * @return User
      */
-    public static function getFakeUserObject(array $data = [])
+    public static function getFakeUserObject(array $data = []): User
     {
         ($data === null) && $data = [];
 
@@ -146,10 +150,8 @@ class TestHelpers
      *
      * @return Chat
      */
-    public static function getFakeChatObject(array $data = [])
+    public static function getFakeChatObject(array $data = []): Chat
     {
-        ($data === null) && $data = [];
-
         return new Chat($data + self::$chat_template);
     }
 
@@ -158,10 +160,10 @@ class TestHelpers
      *
      * @return array
      */
-    public static function getFakeRecordedAudio()
+    public static function getFakeRecordedAudio(): array
     {
         $mime_type = ['audio/ogg', 'audio/mpeg', 'audio/vnd.wave', 'audio/x-ms-wma', 'audio/basic'];
-        $data      = [
+        return [
             'file_id'   => mt_rand(1, 999),
             'duration'  => (string) mt_rand(1, 99) . ':' . mt_rand(1, 60),
             'performer' => 'phpunit',
@@ -169,8 +171,6 @@ class TestHelpers
             'mime_type' => $mime_type[array_rand($mime_type, 1)],
             'file_size' => mt_rand(1, 99999),
         ];
-
-        return $data;
     }
 
     /**
@@ -182,12 +182,8 @@ class TestHelpers
      *
      * @return Message
      */
-    public static function getFakeMessageObject(array $message_data = [], array $user_data = [], array $chat_data = [])
+    public static function getFakeMessageObject(array $message_data = [], array $user_data = [], array $chat_data = []): Message
     {
-        ($message_data === null) && $message_data = [];
-        ($user_data === null) && $user_data = [];
-        ($chat_data === null) && $chat_data = [];
-
         return new Message($message_data + [
             'message_id' => mt_rand(),
             'from'       => $user_data + self::$user_template,
@@ -200,7 +196,8 @@ class TestHelpers
     /**
      * Start a fake conversation for the passed command and return the randomly generated ids.
      *
-     * @return array
+     * @return array|false
+     * @throws \Longman\TelegramBot\Exception\TelegramException
      */
     public static function startFakeConversation()
     {
@@ -226,7 +223,7 @@ class TestHelpers
      *
      * @param array $credentials
      */
-    public static function emptyDb(array $credentials)
+    public static function emptyDb(array $credentials): void
     {
         $dsn = 'mysql:host=' . $credentials['host'] . ';dbname=' . $credentials['database'];
         if (!empty($credentials['port'])) {


### PR DESCRIPTION
| ?            |  !
|---           | ---
| Type         | improvement
| BC Break     | yes
| Fixed issues | n/a

#### Summary

This PR sets the minimum requirement to PHP 7.2.
Introduce strictly typed parameters and return types.
