### PR TITLE
Fix path assignment for download and upload paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Exclamation symbols (:exclamation:) note something of importance e.g. breaking c
 ### Deprecated
 ### Removed
 ### Fixed
+- Ensure download and upload path variables are defined.
 ### Security
 
 ## [0.70.0] - 2020-12-21

--- a/src/Telegram.php
+++ b/src/Telegram.php
@@ -90,14 +90,14 @@ class Telegram
      *
      * @var string
      */
-    protected $upload_path;
+    protected $upload_path = '';
 
     /**
      * Download path
      *
      * @var string
      */
-    protected $download_path;
+    protected $download_path = '';
 
     /**
      * MySQL integration

--- a/tests/Unit/TelegramTest.php
+++ b/tests/Unit/TelegramTest.php
@@ -18,11 +18,11 @@ use Longman\TelegramBot\Telegram;
 use Longman\TelegramBot\TelegramLog;
 
 /**
- * @package         TelegramTest
+ * @link            https://github.com/php-telegram-bot/core
  * @author          Avtandil Kikabidze <akalongman@gmail.com>
  * @copyright       Avtandil Kikabidze <akalongman@gmail.com>
  * @license         http://opensource.org/licenses/mit-license.php  The MIT License (MIT)
- * @link            https://github.com/php-telegram-bot/core
+ * @package         TelegramTest
  */
 class TelegramTest extends TestCase
 {
@@ -131,6 +131,18 @@ class TelegramTest extends TestCase
 
         $tg->addCommandsPath($this->custom_commands_paths[0]);
         self::assertCount(4, $tg->getCommandsPaths());
+    }
+
+    public function testSettingDownloadUploadPaths(): void
+    {
+        self::assertEmpty($this->telegram->getDownloadPath());
+        self::assertEmpty($this->telegram->getUploadPath());
+
+        $this->telegram->setDownloadPath('/down/below');
+        $this->telegram->setUploadPath('/up/above');
+
+        self::assertSame('/down/below', $this->telegram->getDownloadPath());
+        self::assertSame('/up/above', $this->telegram->getUploadPath());
     }
 
     public function testGetCommandsList(): void


### PR DESCRIPTION
| ?            |  !
|---           | ---
| Type         | bug
| BC Break     | no
| Fixed issues | n/a

#### Summary

Define empty path for download and upload path variables, to prevent `must be of the type string, null returned` error
