### PR TITLE
Allow custom Bot API server to be used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Exclamation symbols (:exclamation:) note something of importance e.g. breaking c
 ### Notes
 - [:ledger: View file changes][Unreleased]
 ### Added
+- Define a custom Bot API server and file download URI.
 ### Changed
 - Improved error messages for empty input.
 - Log update when processing it, not when fetching input.

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ A Telegram Bot based on the official [Telegram Bot API]
     - [Create your first bot](#create-your-first-bot)
     - [Require this package with Composer](#require-this-package-with-composer)
     - [Choose how to retrieve Telegram updates](#choose-how-to-retrieve-telegram-updates)
+- [Using a custom Bot API server](#using-a-custom-bot-api-server)
 - [Webhook installation](#webhook-installation)
     - [Self Signed Certificate](#self-signed-certificate)
     - [Unset Webhook](#unset-webhook)
@@ -199,6 +200,23 @@ The bot can handle updates with [**Webhook**](#webhook-installation) or [**getUp
 | Description | Telegram sends the updates directly to your host | You have to fetch Telegram updates manually |
 | Host with https | Required | Not required |
 | MySQL | Not required | ([Not](#getupdates-without-database)) Required  |
+
+## Using a custom Bot API server
+
+**For advanced users only!**
+
+As from Telegram Bot API 5.0, users can [run their own Bot API server] to handle updates.
+This means, that the PHP Telegram Bot needs to be configured to serve that custom URI.
+Additionally, you can define the URI where uploaded files to the bot can be downloaded (note the `{API_KEY}` placeholder).
+
+```php
+Longman\TelegramBot\Request::setCustomBotApiUri(
+    $api_base_uri          = 'https://your-bot-api-server', // Default: https://api.telegram.org
+    $api_base_download_uri = '/path/to/files/{API_KEY}'     // Default: /file/bot{API_KEY}
+);
+```
+
+**Note:** If you are running your bot in `--local` mode, you won't need the `Request::downloadFile()` method, since you can then access your files directly from the absolute path returned by `Request::getFile()`.
 
 ## Webhook installation
 
@@ -657,6 +675,7 @@ Credit list in [CREDITS](CREDITS)
 
 [Telegram Bot API]: https://core.telegram.org/bots/api "Telegram Bot API"
 [Composer]: https://getcomposer.org/ "Composer"
+[run their own Bot API server]: https://core.telegram.org/bots/api#using-a-local-bot-api-server "Using a Local Bot API Server"
 [example-bot repository]: https://github.com/php-telegram-bot/example-bot "Example Bot repository"
 [api-setwebhook]: https://core.telegram.org/bots/api#setwebhook "Webhook on Telegram Bot API"
 [set.php]: https://github.com/php-telegram-bot/example-bot/blob/master/set.php "example set.php"

--- a/src/Request.php
+++ b/src/Request.php
@@ -117,6 +117,13 @@ class Request
     private static $api_base_uri = 'https://api.telegram.org';
 
     /**
+     * URI of the Telegram API for downloading files (relative to $api_base_url or absolute)
+     *
+     * @var string
+     */
+    private static $api_base_download_uri = '/file/bot{API_KEY}';
+
+    /**
      * Guzzle Client object
      *
      * @var ClientInterface
@@ -290,6 +297,20 @@ class Request
     public static function setClient(ClientInterface $client): void
     {
         self::$client = $client;
+    }
+
+    /**
+     * Set a custom Bot API URL
+     *
+     * @param string $api_base_uri
+     * @param string $api_base_download_uri
+     */
+    public static function setCustomBotApiUri(string $api_base_uri, string $api_base_download_uri = ''): void
+    {
+        self::$api_base_uri = $api_base_uri;
+        if ($api_base_download_uri !== '') {
+            self::$api_base_download_uri = $api_base_download_uri;
+        }
     }
 
     /**
@@ -532,8 +553,9 @@ class Request
         $debug_handle = TelegramLog::getDebugLogTempStream();
 
         try {
+            $base_download_uri = str_replace('{API_KEY}', self::$telegram->getApiKey(), self::$api_base_download_uri);
             self::$client->get(
-                '/file/bot' . self::$telegram->getApiKey() . '/' . $tg_file_path,
+                "{$base_download_uri}/{$tg_file_path}",
                 ['debug' => $debug_handle, 'sink' => $file_path]
             );
 


### PR DESCRIPTION
| ?            |  !
|---           | ---
| Type         | feature
| BC Break     | no
| Fixed issues | #1161 

#### Summary

Add a new method `Longman\TelegramBot\Request::setCustomBotApiUri()` to define a custom Bot API and file download URI, which is used for handling updates and in `Request::downloadFile()`.