### PR TITLE
Fix getUpdates method to retrieve all updates when no limit is set.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Exclamation symbols (:exclamation:) note something of importance e.g. breaking c
 ### Deprecated
 ### Removed
 ### Fixed
+- `getUpdates` method wrongly sends only 1 Update when a limit of 0 is passed.
 ### Security
 
 ## [0.70.1] - 2020-12-25

--- a/src/Telegram.php
+++ b/src/Telegram.php
@@ -391,13 +391,13 @@ class Telegram
     /**
      * Handle getUpdates method
      *
-     * @param int $limit
-     * @param int $timeout
+     * @param int|null $limit
+     * @param int|null $timeout
      *
      * @return ServerResponse
      * @throws TelegramException
      */
-    public function handleGetUpdates(int $limit = 0, int $timeout = 0): ServerResponse
+    public function handleGetUpdates(?int $limit = null, ?int $timeout = null): ServerResponse
     {
         if (empty($this->bot_username)) {
             throw new TelegramException('Bot Username is not defined!');


### PR DESCRIPTION
| ?            |  !
|---           | ---
| Type         | bug
| BC Break     | no
| Fixed issues | n/a

#### Summary

Fix for `getUpdates` method, when no explicit limit is defined. It seems the Bot API return value when passing `0` as the limit has changed. Before it would send 100 updates, now it sends just 1. By changing the value to `null`, the parameter is actively ignored, applying the default of 100.