### PR TITLE
Pass correct message text to commands run via Telegram::runCommands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Exclamation symbols (:exclamation:) note something of importance e.g. breaking c
 ### Removed
 ### Fixed
 - `getUpdates` method wrongly sends only 1 Update when a limit of 0 is passed.
+- `Telegram::runCommands()` now passes the correct message text to the commands.
 ### Security
 
 ## [0.70.1] - 2020-12-25

--- a/src/Telegram.php
+++ b/src/Telegram.php
@@ -1036,14 +1036,13 @@ class Telegram
             ]);
         };
 
-        // Required for isAdmin() check inside getCommandObject()
-        $this->update = $newUpdate();
-
-        // Load up-to-date commands list
-        $this->commands_objects = $this->getCommandsList();
-
         foreach ($commands as $command) {
             $this->update = $newUpdate($command);
+
+            // Load up-to-date commands list
+            if (empty($this->commands_objects)) {
+                $this->commands_objects = $this->getCommandsList();
+            }
 
             $this->executeCommand($this->update->getMessage()->getCommand());
         }


### PR DESCRIPTION
| ?            |  !
|---           | ---
| Type         | bug
| BC Break     | no
| Fixed issues | #1180

#### Summary

Make sure the command text is properly passed via the Update object when running commands via `Telegram::runCommands`.
