### PR TITLE
Accept chat ID as integer and string for request limiter counter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Exclamation symbols (:exclamation:) note something of importance e.g. breaking c
 ### Fixed
 - `getUpdates` method wrongly sends only 1 Update when a limit of 0 is passed.
 - `Telegram::runCommands()` now passes the correct message text to the commands.
+- Request limiter accepts chat ID as integer and string.
 ### Security
 
 ## [0.70.1] - 2020-12-25

--- a/src/DB.php
+++ b/src/DB.php
@@ -1259,13 +1259,13 @@ class DB
     /**
      * Get Telegram API request count for current chat / message
      *
-     * @param int|null    $chat_id
-     * @param string|null $inline_message_id
+     * @param int|string|null $chat_id
+     * @param string|null     $inline_message_id
      *
      * @return array|bool Array containing TOTAL and CURRENT fields or false on invalid arguments
      * @throws TelegramException
      */
-    public static function getTelegramRequestCount(int $chat_id = null, string $inline_message_id = null)
+    public static function getTelegramRequestCount($chat_id = null, string $inline_message_id = null)
     {
         if (!self::isDbConnected()) {
             return false;


### PR DESCRIPTION
| ?            |  !
|---           | ---
| Type         | bug
| BC Break     | no
| Fixed issues | #1176  

#### Summary

The request limiter counter now accepts both integer and string values as the chat ID.
