### PR TITLE
apply mb_strtolower to command_name in processUpdate

### DIFF
--- a/src/Telegram.php
+++ b/src/Telegram.php
@@ -557,7 +557,7 @@ class Telegram
             $type    = $message->getType();
 
             // Let's check if the message object has the type field we're looking for...
-            $command_tmp = $type === 'command' ? $message->getCommand() : $this->getCommandFromType($type);
+            $command_tmp = mb_strtolower($type === 'command' ? $message->getCommand() : $this->getCommandFromType($type));
             // ...and if a fitting command class is available.
             $command_obj = $command_tmp ? $this->getCommandObject($command_tmp) : null;
 


### PR DESCRIPTION
Keys in `\Longman\TelegramBot\Telegram::$commands_objects` get register as all lowercase, but not queried the same way. Apply `mb_strtolower` to `$command_tmp` in `\Longman\TelegramBot\Telegram::processUpdate` to short circuit `\Longman\TelegramBot\Telegram::getCommandObject`. 

fixes #1197 

Obviously, there are many ways to apply `mb_strtolower` here, this could also be done in `\Longman\TelegramBot\Telegram::getCommandObject` as the first statement. This is how I did it, to patch my local installation.