### PR TITLE
Allow defining update types when handling updates via `getUpdates` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Exclamation symbols (:exclamation:) note something of importance e.g. breaking c
 - Bot API 5.1 (ChatMember Update types, Improved Invite Links, Voice Chat). (@massadm, @noplanman)
 ### Changed
 ### Deprecated
+- `Telegram::handleGetUpdates` method should be passed a `$data` array for parameters.
 ### Removed
 ### Fixed
 - `message.edit_date` is now of type `timestamp`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Exclamation symbols (:exclamation:) note something of importance e.g. breaking c
 ### Removed
 ### Fixed
 - `message.edit_date` is now of type `timestamp`.
+- Allow all update types by default when using `getUpdates` method.
 ### Security
 
 ## [0.71.0] - 2021-03-05

--- a/README.md
+++ b/README.md
@@ -372,10 +372,10 @@ $allowed_updates = [
 ];
 
 // When setting the webhook.
-$telegram->setWebhook($hook_url, ['allowed_types' => $allowed_updates]);
+$telegram->setWebhook($hook_url, ['allowed_updates' => $allowed_updates]);
 
 // When handling the getUpdates method.
-$telegram->handleGetUpdates($limit = null, $timeout = null, $allowed_updates);
+$telegram->handleGetUpdates(['allowed_updates' => $allowed_updates]);
 ```
 
 ## Support

--- a/README.md
+++ b/README.md
@@ -341,7 +341,33 @@ $telegram->useGetUpdatesWithoutDatabase();
 
 ## Filter Update
 
-Update processing can be allowed or denied by defining a custom update filter.
+:exclamation: Note that by default, Telegram will send any new update types that may be added in the future. This may cause commands that don't take this into account to break!
+
+It is suggested that you specifically define which update types your bot can receive and handle correctly.
+
+You can define which update types are sent to your bot by defining them when setting the [webhook](#webhook-installation) or passing an array of allowed types when using [getUpdates](#getupdates-installation).
+
+```php
+use Longman\TelegramBot\Entities\Update;
+
+// For all update types currently implemented in this library:
+// $allowed_updates = Update::getUpdateTypes();
+
+// Define the list of allowed Update types manually:
+$allowed_updates = [
+    Update::TYPE_MESSAGE,
+    Update::TYPE_CHANNEL_POST,
+    // etc.
+];
+
+// When setting the webhook.
+$telegram->setWebhook($hook_url, ['allowed_updates' => $allowed_updates]);
+
+// When handling the getUpdates method.
+$telegram->handleGetUpdates(['allowed_updates' => $allowed_updates]);
+```
+
+Alternatively, Update processing can be allowed or denied by defining a custom update filter.
 
 Let's say we only want to allow messages from a user with ID `428`, we can do the following before handling the request:
 
@@ -358,25 +384,6 @@ $telegram->setUpdateFilter(function (Update $update, Telegram $telegram, &$reaso
 ```
 
 The reason for denying an update can be defined with the `$reason` parameter. This text gets written to the debug log.
-
-Alternatively, you can define which update types are handled by your bot, by defining them when setting the [webhook](#webhook-installation) or passing an array of allowed types when using [getUpdates](#getupdates-installation).
-
-```php
-use Longman\TelegramBot\Entities\Update;
-
-// Define the list of allowed Update types here.
-$allowed_updates = [
-    Update::TYPE_MESSAGE,
-    Update::TYPE_CHANNEL_POST,
-    // etc.
-];
-
-// When setting the webhook.
-$telegram->setWebhook($hook_url, ['allowed_updates' => $allowed_updates]);
-
-// When handling the getUpdates method.
-$telegram->handleGetUpdates(['allowed_updates' => $allowed_updates]);
-```
 
 ## Support
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 A Telegram Bot based on the official [Telegram Bot API]
 
-[![API Version](https://img.shields.io/badge/Bot%20API-5.1%20%28March%202021%29-32a2da.svg)](https://core.telegram.org/bots/api#november-4-2020)
+[![API Version](https://img.shields.io/badge/Bot%20API-5.1%20%28March%202021%29-32a2da.svg)](https://core.telegram.org/bots/api#march-9-2021)
 [![Join the bot support group on Telegram](https://img.shields.io/badge/telegram-@PHP__Telegram__Bot__Support-64659d.svg)](https://telegram.me/PHP_Telegram_Bot_Support)
 [![Donate](https://img.shields.io/badge/%F0%9F%92%99-Donate%20%2F%20Support%20Us-blue.svg)](#donate)
 
@@ -33,6 +33,7 @@ A Telegram Bot based on the official [Telegram Bot API]
     - [Unset Webhook](#unset-webhook)
 - [getUpdates installation](#getupdates-installation)
     - [getUpdates without database](#getupdates-without-database)
+- [Filter Update](#filter-update)
 - [Support](#support)
     - [Types](#types)
     - [Inline Query](#inline-query)
@@ -43,7 +44,6 @@ A Telegram Bot based on the official [Telegram Bot API]
     - [getUserProfilePhoto](#getuserprofilephoto)
     - [getFile and downloadFile](#getfile-and-downloadfile)
     - [Send message to all active chats](#send-message-to-all-active-chats)
-    - [Filter Update](#filter-update)
 - [Utils](#utils)
     - [MySQL storage (Recommended)](#mysql-storage-recommended)
         - [External Database connection](#external-database-connection)
@@ -339,6 +339,45 @@ If you choose to / or are obliged to use the `getUpdates` method without a datab
 $telegram->useGetUpdatesWithoutDatabase();
 ```
 
+## Filter Update
+
+Update processing can be allowed or denied by defining a custom update filter.
+
+Let's say we only want to allow messages from a user with ID `428`, we can do the following before handling the request:
+
+```php
+$telegram->setUpdateFilter(function (Update $update, Telegram $telegram, &$reason = 'Update denied by update_filter') {
+    $user_id = $update->getMessage()->getFrom()->getId();
+    if ($user_id === 428) {
+        return true;
+    }
+
+    $reason = "Invalid user with ID {$user_id}";
+    return false;
+});
+```
+
+The reason for denying an update can be defined with the `$reason` parameter. This text gets written to the debug log.
+
+Alternatively, you can define which update types are handled by your bot, by defining them when setting the [webhook](#webhook-installation) or passing an array of allowed types when using [getUpdates](#getupdates-installation).
+
+```php
+use Longman\TelegramBot\Entities\Update;
+
+// Define the list of allowed Update types here.
+$allowed_updates = [
+    Update::TYPE_MESSAGE,
+    Update::TYPE_CHANNEL_POST,
+    // etc.
+];
+
+// When setting the webhook.
+$telegram->setWebhook($hook_url, ['allowed_types' => $allowed_updates]);
+
+// When handling the getUpdates method.
+$telegram->handleGetUpdates($limit = null, $timeout = null, $allowed_updates);
+```
+
 ## Support
 
 ### Types
@@ -432,26 +471,6 @@ $results = Request::sendToActiveChats(
 ```
 
 You can also broadcast a message to users, from the private chat with your bot. Take a look at the [admin commands](#admin-commands) below.
-
-#### Filter Update
-
-Update processing can be allowed or denied by defining a custom update filter.
-
-Let's say we only want to allow messages from a user with ID 428, we can do the following before handling the request:
-
-```php
-$telegram->setUpdateFilter(function (Update $update, Telegram $telegram, &$reason = 'Update denied by update_filter') {
-    $user_id = $update->getMessage()->getFrom()->getId();
-    if ($user_id === 428) {
-        return true;
-    }
-
-    $reason = "Invalid user with ID {$user_id}";
-    return false;
-});
-```
-
-The reason for denying an update can be defined with the `$reason` parameter. This text gets written to the debug log.
 
 ## Utils
 

--- a/src/Entities/Update.php
+++ b/src/Entities/Update.php
@@ -36,26 +36,50 @@ use Longman\TelegramBot\Entities\Payments\ShippingQuery;
  */
 class Update extends Entity
 {
-    public static $update_type_entities = [
-        'message'              => Message::class,
-        'edited_message'       => EditedMessage::class,
-        'channel_post'         => ChannelPost::class,
-        'edited_channel_post'  => EditedChannelPost::class,
-        'inline_query'         => InlineQuery::class,
-        'chosen_inline_result' => ChosenInlineResult::class,
-        'callback_query'       => CallbackQuery::class,
-        'shipping_query'       => ShippingQuery::class,
-        'pre_checkout_query'   => PreCheckoutQuery::class,
-        'poll'                 => Poll::class,
-        'poll_answer'          => PollAnswer::class,
-    ];
+    public const TYPE_MESSAGE              = 'message';
+    public const TYPE_EDITED_MESSAGE       = 'edited_message';
+    public const TYPE_CHANNEL_POST         = 'channel_post';
+    public const TYPE_EDITED_CHANNEL_POST  = 'edited_channel_post';
+    public const TYPE_INLINE_QUERY         = 'inline_query';
+    public const TYPE_CHOSEN_INLINE_RESULT = 'chosen_inline_result';
+    public const TYPE_CALLBACK_QUERY       = 'callback_query';
+    public const TYPE_SHIPPING_QUERY       = 'shipping_query';
+    public const TYPE_PRE_CHECKOUT_QUERY   = 'pre_checkout_query';
+    public const TYPE_POLL                 = 'poll';
+    public const TYPE_POLL_ANSWER          = 'poll_answer';
+    public const TYPE_MY_CHAT_MEMBER       = 'my_chat_member';
+    public const TYPE_CHAT_MEMBER          = 'chat_member';
 
     /**
      * {@inheritdoc}
      */
     protected function subEntities(): array
     {
-        return self::$update_type_entities;
+        return [
+            self::TYPE_MESSAGE              => Message::class,
+            self::TYPE_EDITED_MESSAGE       => EditedMessage::class,
+            self::TYPE_CHANNEL_POST         => ChannelPost::class,
+            self::TYPE_EDITED_CHANNEL_POST  => EditedChannelPost::class,
+            self::TYPE_INLINE_QUERY         => InlineQuery::class,
+            self::TYPE_CHOSEN_INLINE_RESULT => ChosenInlineResult::class,
+            self::TYPE_CALLBACK_QUERY       => CallbackQuery::class,
+            self::TYPE_SHIPPING_QUERY       => ShippingQuery::class,
+            self::TYPE_PRE_CHECKOUT_QUERY   => PreCheckoutQuery::class,
+            self::TYPE_POLL                 => Poll::class,
+            self::TYPE_POLL_ANSWER          => PollAnswer::class,
+            self::TYPE_MY_CHAT_MEMBER       => ChatMemberUpdated::class,
+            self::TYPE_CHAT_MEMBER          => ChatMemberUpdated::class,
+        ];
+    }
+
+    /**
+     * Get the list of all available update types
+     *
+     * @return string[]
+     */
+    public static function getUpdateTypes(): array
+    {
+        return array_keys((new self([]))->subEntities());
     }
 
     /**
@@ -65,8 +89,7 @@ class Update extends Entity
      */
     public function getUpdateType(): ?string
     {
-        $types = array_keys($this->subEntities());
-        foreach ($types as $type) {
+        foreach (self::getUpdateTypes() as $type) {
             if ($this->getProperty($type)) {
                 return $type;
             }

--- a/src/Entities/Update.php
+++ b/src/Entities/Update.php
@@ -34,24 +34,26 @@ use Longman\TelegramBot\Entities\Payments\ShippingQuery;
  */
 class Update extends Entity
 {
+    public static $update_type_entities = [
+        'message'              => Message::class,
+        'edited_message'       => EditedMessage::class,
+        'channel_post'         => ChannelPost::class,
+        'edited_channel_post'  => EditedChannelPost::class,
+        'inline_query'         => InlineQuery::class,
+        'chosen_inline_result' => ChosenInlineResult::class,
+        'callback_query'       => CallbackQuery::class,
+        'shipping_query'       => ShippingQuery::class,
+        'pre_checkout_query'   => PreCheckoutQuery::class,
+        'poll'                 => Poll::class,
+        'poll_answer'          => PollAnswer::class,
+    ];
+
     /**
      * {@inheritdoc}
      */
     protected function subEntities(): array
     {
-        return [
-            'message'              => Message::class,
-            'edited_message'       => EditedMessage::class,
-            'channel_post'         => ChannelPost::class,
-            'edited_channel_post'  => EditedChannelPost::class,
-            'inline_query'         => InlineQuery::class,
-            'chosen_inline_result' => ChosenInlineResult::class,
-            'callback_query'       => CallbackQuery::class,
-            'shipping_query'       => ShippingQuery::class,
-            'pre_checkout_query'   => PreCheckoutQuery::class,
-            'poll'                 => Poll::class,
-            'poll_answer'          => PollAnswer::class,
-        ];
+        return self::$update_type_entities;
     }
 
     /**

--- a/src/Telegram.php
+++ b/src/Telegram.php
@@ -416,7 +416,7 @@ class Telegram
 
         // By default, allow ALL known update types.
         if ($allowed_updates === null) {
-            $allowed_updates = array_keys(Update::$update_type_entities);
+            $allowed_updates = Update::getUpdateTypes();
         }
         $offset = 0;
 

--- a/src/Telegram.php
+++ b/src/Telegram.php
@@ -415,9 +415,11 @@ class Telegram
             );
         }
 
-        $offset          = 0;
-        $limit           = null;
-        $allowed_updates = null;
+        $offset = 0;
+        $limit  = null;
+
+        // By default, get update types sent by Telegram.
+        $allowed_updates = [];
 
         // @todo Backwards compatibility for old signature, remove in next version.
         if (!is_array($data)) {
@@ -432,11 +434,6 @@ class Telegram
             $limit           = $data['limit'] ?? $limit;
             $timeout         = $data['timeout'] ?? $timeout;
             $allowed_updates = $data['allowed_updates'] ?? $allowed_updates;
-        }
-
-        // By default, allow ALL known update types.
-        if ($allowed_updates === null) {
-            $allowed_updates = Update::getUpdateTypes();
         }
 
         // Take custom input into account.


### PR DESCRIPTION
| ?            |  !
|---           | ---
| Type         | bug
| BC Break     | no
| Fixed issues | #1201 

#### Summary

Add an extra parameter to `Telegram::handleGetUpdates` to define allowed types. If no update types are passed, allow ALL update types, to make sure that special ones like `chat_member` (which MUST be defined to receive) also get fetched.