### PR TITLE
PSR4 command classes include

### DIFF
--- a/src/Telegram.php
+++ b/src/Telegram.php
@@ -15,6 +15,7 @@ defined('TB_BASE_PATH') || define('TB_BASE_PATH', __DIR__);
 defined('TB_BASE_COMMANDS_PATH') || define('TB_BASE_COMMANDS_PATH', TB_BASE_PATH . '/Commands');
 
 use Exception;
+use InvalidArgumentException;
 use Longman\TelegramBot\Commands\AdminCommand;
 use Longman\TelegramBot\Commands\Command;
 use Longman\TelegramBot\Commands\SystemCommand;
@@ -310,10 +311,11 @@ class Telegram
      *
      * @return string|null
      */
-    private function getCommandClassName(string $auth, string $command): ?string
+    public function getCommandClassName(string $auth, string $command): ?string
     {
         $command = mb_strtolower($command);
         $auth = $this->ucFirstUnicode($auth);
+
         if (!empty($this->commandsClasses[$auth][$command])) {
             $className = $this->commandsClasses[$auth][$command];
             if (class_exists($className)){
@@ -774,11 +776,15 @@ class Telegram
     {
         if (!class_exists($className))
         {
-            TelegramLog::error('Command class name: "' . $className . '" does not exist.');
+            $error = 'Command class name: "' . $className . '" does not exist.';
+            TelegramLog::error($error);
+            throw new InvalidArgumentException($error);
         }
-        if (!empty($command))
+        if (empty($command))
         {
-            TelegramLog::error('Command Name "' . $command . '" not set.');
+            $error = 'Command Name "' . $command . '" not set.';
+            TelegramLog::error($error);
+            throw new InvalidArgumentException($error);
         }
 
         if (!is_array($this->commandsClasses))
@@ -842,6 +848,16 @@ class Telegram
     public function getCommandsPaths(): array
     {
         return $this->commands_paths;
+    }
+
+    /**
+     * Return the list of commands classes
+     *
+     * @return array
+     */
+    public function getCommandsClasses(): array
+    {
+        return $this->commandsClasses;
     }
 
     /**

--- a/tests/Unit/TelegramTest.php
+++ b/tests/Unit/TelegramTest.php
@@ -13,6 +13,7 @@ namespace Longman\TelegramBot\Tests\Unit;
 
 use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
 use Exception;
+use Longman\TelegramBot\Commands\AdminCommands\WhoisCommand;
 use Longman\TelegramBot\Commands\UserCommands\StartCommand;
 use Longman\TelegramBot\Entities\Update;
 use Longman\TelegramBot\Exception\TelegramException;
@@ -139,25 +140,26 @@ class TelegramTest extends TestCase
     {
         $tg = $this->telegram;
         $class = StartCommand::class;
+        $aClass = WhoisCommand::class;
 
         self::assertCount(3, $tg->getCommandsClasses());
 
         try {
-            $tg->addCommandsClass('test', 'not\exist\Class', 'user');
+            $tg->addCommandsClass('not\exist\Class');
         }
         catch (\Exception $ex){}
         self::assertCount(0, $tg->getCommandsClasses()['User']);
 
         try {
-            $tg->addCommandsClass('', $class, 'user');
+            $tg->addCommandsClass('');
         }
         catch (\Exception $ex){}
         self::assertCount(0, $tg->getCommandsClasses()['User']);
 
-        $tg->addCommandsClass('test', $class, 'user');
+        $tg->addCommandsClass($class);
         self::assertCount(1, $tg->getCommandsClasses()['User']);
 
-        $tg->addCommandsClass('testadmin', $class, 'admin');
+        $tg->addCommandsClass($aClass);
         self::assertCount(1, $tg->getCommandsClasses()['Admin']);
 
     }
@@ -191,9 +193,10 @@ class TelegramTest extends TestCase
         $class = $this->telegram->getCommandClassName('user', 'notexist');
         self::assertNull($class);
 
-        $this->telegram->addCommandsClass('test', $className, 'user');
-        $class = $this->telegram->getCommandClassName('user', 'test');
+        $this->telegram->addCommandsClass($className);
+        $class = $this->telegram->getCommandClassName('user', 'start');
         self::assertNotNull($class);
+
         self::assertSame($className, $class);
 
     }


### PR DESCRIPTION
<!--
Important:
If this pull request is not related to any issue and contains a new feature, please create an issue first for discussion.
https://github.com/php-telegram-bot/core/issues/new?template=Feature_Request.md

Make sure this pull request is pointed towards the "develop" branch and refers to any issue that it's related to!
-->

<!-- Fill in the relevant information below to help triage your pull request. -->

| ?            |  !
|---           | ---
| Type         | bug + feature
| BC Break     | yes
| Fixed issues | 1205

#### Summary
Add support to include commands classes via PSR4, and old method (pathes) works too.
Fix regex for search 'namespace' 
Add tests.