### PR TITLE
Possibility to connect to MySQL db with using unix socket connection

### DIFF
--- a/src/DB.php
+++ b/src/DB.php
@@ -78,8 +78,13 @@ class DB
         if (empty($credentials)) {
             throw new TelegramException('MySQL credentials not provided!');
         }
+        if (isset($credentials['unix_socket'])) {
+            $dsn = 'mysql:unix_socket=' . $credentials['unix_socket'];
+        } else {
+            $dsn = 'mysql:host=' . $credentials['host'];
+        }
+        $dsn .= ';dbname=' . $credentials['database'];
 
-        $dsn = 'mysql:host=' . $credentials['host'] . ';dbname=' . $credentials['database'];
         if (!empty($credentials['port'])) {
             $dsn .= ';port=' . $credentials['port'];
         }


### PR DESCRIPTION
<!--
Important:
If this pull request is not related to any issue and contains a new feature, please create an issue first for discussion.
https://github.com/php-telegram-bot/core/issues/new?template=Feature_Request.md

Make sure this pull request is pointed towards the "develop" branch and refers to any issue that it's related to!
-->

<!-- Fill in the relevant information below to help triage your pull request. -->

| ?            |  !
|---           | ---
| Type         | improvement
| BC Break     | no 
| Fixed issues | #1219

#### Summary

There is a new option for MySQL credentials options to connect to MySQL db with using unix socket connection.


