### PR TITLE
Fix Telegram::runCommands for User and nested calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Exclamation symbols (:exclamation:) note something of importance e.g. breaking c
 ### Added
 - Bot API 5.2 (Payments 2.0).
 ### Changed
+- `Telegram::runCommands` returns array of `ServerResponse` objects of executed commands.
 ### Deprecated
 ### Removed
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Exclamation symbols (:exclamation:) note something of importance e.g. breaking c
 ### Deprecated
 ### Removed
 ### Fixed
+- Nested and user-triggered `Telegram::runCommands`.
 ### Security
 
 ## [0.72.0] - 2021-04-16

--- a/src/Telegram.php
+++ b/src/Telegram.php
@@ -20,8 +20,10 @@ use Longman\TelegramBot\Commands\AdminCommand;
 use Longman\TelegramBot\Commands\Command;
 use Longman\TelegramBot\Commands\SystemCommand;
 use Longman\TelegramBot\Commands\UserCommand;
+use Longman\TelegramBot\Entities\Chat;
 use Longman\TelegramBot\Entities\ServerResponse;
 use Longman\TelegramBot\Entities\Update;
+use Longman\TelegramBot\Entities\User;
 use Longman\TelegramBot\Exception\TelegramException;
 use PDO;
 use RecursiveDirectoryIterator;
@@ -1125,38 +1127,49 @@ class Telegram
 
         $this->run_commands = true;
 
-        $result = Request::getMe();
-
-        if ($result->isOk()) {
-            $result = $result->getResult();
-
-            $bot_id       = $result->getId();
-            $bot_name     = $result->getFirstName();
-            $bot_username = $result->getUsername();
+        // Check if this request has a user Update / comes from Telegram.
+        if ($userUpdate = $this->update) {
+            $from = $this->update->getMessage()->getFrom();
+            $chat = $this->update->getMessage()->getChat();
         } else {
-            $bot_id       = $this->getBotId();
-            $bot_name     = $this->getBotUsername();
-            $bot_username = $this->getBotUsername();
+            // Fall back to the Bot user.
+            $from = new User([
+                'id'         => $this->getBotId(),
+                'first_name' => $this->getBotUsername(),
+                'username'   => $this->getBotUsername(),
+            ]);
+
+            // Try to get "live" Bot info.
+            $response = Request::getMe();
+            if ($response->isOk()) {
+                /** @var User $result */
+                $result = $response->getResult();
+
+                $from = new User([
+                    'id'         => $result->getId(),
+                    'first_name' => $result->getFirstName(),
+                    'username'   => $result->getUsername(),
+                ]);
+            }
+
+            // Give Bot access to admin commands.
+            $this->enableAdmin($from->getId());
+
+            // Lock the bot to a private chat context.
+            $chat = new Chat([
+                'id'   => $from->getId(),
+                'type' => 'private',
+            ]);
         }
 
-        // Give bot access to admin commands
-        $this->enableAdmin($bot_id);
-
-        $newUpdate = static function ($text = '') use ($bot_id, $bot_name, $bot_username) {
+        $newUpdate = static function ($text = '') use ($from, $chat) {
             return new Update([
-                'update_id' => 0,
+                'update_id' => -1,
                 'message'   => [
-                    'message_id' => 0,
-                    'from'       => [
-                        'id'         => $bot_id,
-                        'first_name' => $bot_name,
-                        'username'   => $bot_username,
-                    ],
+                    'message_id' => -1,
                     'date'       => time(),
-                    'chat'       => [
-                        'id'   => $bot_id,
-                        'type' => 'private',
-                    ],
+                    'from'       => json_decode($from->toJson(), true),
+                    'chat'       => json_decode($chat->toJson(), true),
                     'text'       => $text,
                 ],
             ]);
@@ -1165,13 +1178,14 @@ class Telegram
         foreach ($commands as $command) {
             $this->update = $newUpdate($command);
 
-            // Load up-to-date commands list
-            if (empty($this->commands_objects)) {
-                $this->commands_objects = $this->getCommandsList();
-            }
+            // Refresh commands list for new Update object.
+            $this->commands_objects = $this->getCommandsList();
 
             $this->executeCommand($this->update->getMessage()->getCommand());
         }
+
+        // Reset Update to initial context.
+        $this->update = $userUpdate;
     }
 
     /**

--- a/src/Telegram.php
+++ b/src/Telegram.php
@@ -1117,9 +1117,11 @@ class Telegram
      *
      * @param array $commands
      *
+     * @return ServerResponse[]
+     *
      * @throws TelegramException
      */
-    public function runCommands(array $commands): void
+    public function runCommands(array $commands): array
     {
         if (empty($commands)) {
             throw new TelegramException('No command(s) provided!');
@@ -1175,17 +1177,21 @@ class Telegram
             ]);
         };
 
+        $responses = [];
+
         foreach ($commands as $command) {
             $this->update = $newUpdate($command);
 
             // Refresh commands list for new Update object.
             $this->commands_objects = $this->getCommandsList();
 
-            $this->executeCommand($this->update->getMessage()->getCommand());
+            $responses[] = $this->executeCommand($this->update->getMessage()->getCommand());
         }
 
         // Reset Update to initial context.
         $this->update = $userUpdate;
+
+        return $responses;
     }
 
     /**


### PR DESCRIPTION
Fix running custom commands via `Telegram::runCommands`.
Fixes #1214

e.g.
```php
// ParentCommand.php
public function execute(): ServerResponse
{
    $responses = $this->getTelegram()->runCommands(['/child with params']);

    // Do other stuff...

    return Request::emptyResponse();
}
```

```php
// ChildCommand.php
public function execute(): ServerResponse
{
    // Do more stuff here...

    return Request::emptyResponse();
}
```