### PR TITLE
Fixed non-working drop_pending_updates in setWebhook and deleteWebhook

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -665,7 +665,7 @@ class Request
      */
     protected static function addDummyParamIfNecessary(string $action, array &$data): void
     {
-        if (in_array($action, self::$actions_need_dummy_param, true)) {
+        if (empty($data) && in_array($action, self::$actions_need_dummy_param, true)) {
             // Can be anything, using a single letter to minimise request size.
             $data = ['d'];
         }

--- a/src/Telegram.php
+++ b/src/Telegram.php
@@ -1029,6 +1029,7 @@ class Telegram
             'certificate',
             'max_connections',
             'allowed_updates',
+            'drop_pending_updates'
         ]));
         $data['url'] = $url;
 

--- a/src/Telegram.php
+++ b/src/Telegram.php
@@ -1027,6 +1027,7 @@ class Telegram
 
         $data        = array_intersect_key($data, array_flip([
             'certificate',
+            'ip_address',
             'max_connections',
             'allowed_updates',
             'drop_pending_updates'


### PR DESCRIPTION
As described in #1225 the `setWebhook` method filters the data array for allowed options, but doesn't allow `drop_pending_updates`. This PR fixes this.