### PR TITLE
PHP 8.1 deprecations fix

### DIFF
--- a/src/Entities/Message.php
+++ b/src/Entities/Message.php
@@ -158,7 +158,7 @@ class Message extends Entity
         }
 
         $full_command = $this->getFullCommand();
-        if (strpos($full_command, '/') !== 0) {
+        if (!is_string($full_command) || strpos($full_command, '/') !== 0) {
             return null;
         }
         $full_command = substr($full_command, 1);
@@ -261,7 +261,7 @@ class Message extends Entity
             'reply_markup',
         ];
 
-        $is_command = strlen($this->getCommand()) > 0;
+        $is_command = is_string($command = $this->getCommand()) && strlen($command) > 0;
         foreach ($types as $type) {
             if ($this->getProperty($type) !== null) {
                 if ($is_command && $type === 'text') {


### PR DESCRIPTION
| ?            |  !
|---           | ---
| Type         | improvement
| BC Break     | no

#### Summary

At php 8.1 got some deprecations:
```
Deprecated: strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated in /srv/app/vendor/longman/telegram-bot/src/Entities/Message.php on line 161

Deprecated: strlen(): Passing null to parameter #1 ($string) of type string is deprecated in /srv/app/vendor/longman/telegram-bot/src/Entities/Message.php on line 264
```

Fix ensures that passed parameter is a string.