### PR TITLE
Make sure setCustomBotApiUri has an effect if Telegram object was already instantiated.

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -327,6 +327,10 @@ class Request
         if ($api_base_download_uri !== '') {
             self::$api_base_download_uri = $api_base_download_uri;
         }
+
+        if (self::$telegram) {
+            self::initialize(self::$telegram);
+        }
     }
 
     /**

--- a/src/Request.php
+++ b/src/Request.php
@@ -323,13 +323,13 @@ class Request
      */
     public static function setCustomBotApiUri(string $api_base_uri, string $api_base_download_uri = ''): void
     {
+        if (self::$client) {
+            throw new TelegramException('setCustomBotApiUri() needs to be called before the Telegram object gets instantiated.');
+        }
+
         self::$api_base_uri = $api_base_uri;
         if ($api_base_download_uri !== '') {
             self::$api_base_download_uri = $api_base_download_uri;
-        }
-
-        if (self::$telegram) {
-            self::initialize(self::$telegram);
         }
     }
 


### PR DESCRIPTION
Should fix problems like #1295 