### PR TITLE
add secret_token

### DIFF
--- a/src/Telegram.php
+++ b/src/Telegram.php
@@ -1063,6 +1063,7 @@ class Telegram
             'max_connections',
             'allowed_updates',
             'drop_pending_updates',
+            'secret_token',
         ]));
         $data['url'] = $url;
 


### PR DESCRIPTION
https://core.telegram.org/bots/api#setwebhook
```
A secret token to be sent in a header “X-Telegram-Bot-Api-Secret-Token” in every webhook request, 1-256 characters. Only characters A-Z, a-z, 0-9, _ and - are allowed. The header is useful to ensure that the request comes from a webhook set by you.
```

<!--
Important:
If this pull request is not related to any issue and contains a new feature, please create an issue first for discussion.
https://github.com/php-telegram-bot/core/issues/new?template=Feature_Request.md

Make sure this pull request is pointed towards the "develop" branch and refers to any issue that it's related to!
-->

<!-- Fill in the relevant information below to help triage your pull request. -->

| ?            |  !
|---           | ---
| Type         | improvement
| BC Break     | no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

<!-- Provide a summary of your change. -->
