### PR TITLE
Make public to edit commands_objects

### DIFF
--- a/src/Telegram.php
+++ b/src/Telegram.php
@@ -99,7 +99,7 @@ class Telegram
      *
      * @var array
      */
-    protected $commands_objects = [];
+    public $commands_objects = [];
 
     /**
      * Current Update object


### PR DESCRIPTION
When do not use ```runCommands``` or ```processUpdate```,  ```$command_object``` cannot be updated so cannot run ```executeCommand```:
It appears like this:
- create a new Command
- call it by executeCommand
- this command's __construct can be run
- this commans's execute cannot be run

Due to:
https://github.com/php-telegram-bot/core/blob/0.77.1/src/Telegram.php#L610
https://github.com/php-telegram-bot/core/blob/0.77.1/src/Telegram.php#L661

<!--
Important:
If this pull request is not related to any issue and contains a new feature, please create an issue first for discussion.
https://github.com/php-telegram-bot/core/issues/new?template=Feature_Request.md

Make sure this pull request is pointed towards the "develop" branch and refers to any issue that it's related to!
-->

<!-- Fill in the relevant information below to help triage your pull request. -->

| ?            |  !
|---           | ---
| Type         |  improvement
| BC Break     | no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

<!-- Provide a summary of your change. -->
