### PR TITLE
Nullable return type for the getLastUpdateId() method

### DIFF
--- a/src/Telegram.php
+++ b/src/Telegram.php
@@ -1255,9 +1255,9 @@ class Telegram
     /**
      * Return last update id
      *
-     * @return int
+     * @return int|null
      */
-    public function getLastUpdateId(): int
+    public function getLastUpdateId(): ?int
     {
         return $this->last_update_id;
     }


### PR DESCRIPTION
| ?            |  !
|---           | ---
| Type         | bug
| BC Break     | no 
| Fixed issues | 

#### Summary

If I handle updates the following way:

```
$tg = new Telegram('token', 'username');
$tg->useGetUpdatesWithoutDatabase();
$tg->handleGetUpdates();
$lastUpdateId = $tg->getLastUpdateId();
```
And there are no updates, then I get the following error:
Longman\TelegramBot\Telegram::getLastUpdateId(): Return value must be of type int, null returned

Actually, _null_ is a fine result in this case, so I suppose that getLastUpdateId() could be able to return _null_.