### PR TITLE
Add method to inject EntityManager into Symfony

### DIFF
--- a/src/Telegram.php
+++ b/src/Telegram.php
@@ -135,6 +135,14 @@ class Telegram
      * @var PDO
      */
     protected $pdo;
+    
+    
+    /**
+     * EntityManager object
+     *
+     * @var EntityManagerInterface
+     */
+    public $em;
 
     /**
      * Commands config
@@ -259,6 +267,11 @@ class Telegram
         $this->mysql_enabled = true;
 
         return $this;
+    }
+    
+    public function enableEntityManager(EntityManagerInterface $em): Telegram
+    {
+        $this->em = $em;
     }
 
     /**


### PR DESCRIPTION
| ?            |  !
|---           | ---
| Type         | improvement
| BC Break     | no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

Adding ability to inject EntityManager if we use this php-telegram-bot into Symfony project

```php
<?php

namespace App\TelegramCommand;

use App\Entity\Contact;
use Longman\TelegramBot\Commands\UserCommand;
use Longman\TelegramBot\Entities\ServerResponse;
use Longman\TelegramBot\Request;

/**
 * User "/subscribe" command.
 *
 * Get weather info for any place.
 * This command requires an API key to be set via command config.
 */
class SubscribeCommand extends UserCommand
{
    /**
     * @var string
     */
    protected $name = 'subscribe';

    /**
     * @var string
     */
    protected $description = 'Start msg';

    /**
     * @var string
     */
    protected $usage = '/subscribe';

    /**
     * @var string
     */
    protected $version = '1.2.0';

    public function execute(): ServerResponse
    {
        $message = $this->getMessage();
        $chat_id = $message->getChat()->getId();
//        $user_id = $message->getFrom()->getId();
        $contactId = $message->getText(true);

        $contact = $this->telegram->em->getRepository(Contact::class)->findOneBy(['contactId' => $contactId]);

        if ($contactId) {
            $text = 'Отлично! Мы привязали чатбот к вашему ContactId';
        } else {
            $text = 'К сожалению, мы не смогли найти аккаунт по вашему ContactId';
        }

        $data = [
            'chat_id' => $chat_id,
            'text' => $text,
        ];

        return Request::sendMessage($data);
    }
}

```