### PR TITLE
Message::getType lost some value

### DIFF
--- a/src/Entities/Message.php
+++ b/src/Entities/Message.php
@@ -253,6 +253,7 @@ class Message extends Entity
             'location',
             'venue',
             'poll',
+            'dice',
             'new_chat_members',
             'left_chat_member',
             'new_chat_title',
@@ -269,6 +270,9 @@ class Message extends Entity
             'successful_payment',
             'passport_data',
             'proximity_alert_triggered',
+            'forum_topic_created',
+            'forum_topic_closed',
+            'forum_topic_reopened'
             'video_chat_scheduled',
             'video_chat_started',
             'video_chat_ended',

--- a/src/Entities/Message.php
+++ b/src/Entities/Message.php
@@ -272,7 +272,7 @@ class Message extends Entity
             'proximity_alert_triggered',
             'forum_topic_created',
             'forum_topic_closed',
-            'forum_topic_reopened'
+            'forum_topic_reopened',
             'video_chat_scheduled',
             'video_chat_started',
             'video_chat_ended',


### PR DESCRIPTION
dice
forum_topic_created
forum_topic_closed
forum_topic_reopened

<!--
Important:
If this pull request is not related to any issue and contains a new feature, please create an issue first for discussion.
https://github.com/php-telegram-bot/core/issues/new?template=Feature_Request.md

Make sure this pull request is pointed towards the "develop" branch and refers to any issue that it's related to!
-->

<!-- Fill in the relevant information below to help triage your pull request. -->

| ?            |  !
|---           | ---
| Type         | bug
| BC Break     | no
| Fixed issues | #1371

#### Summary

These are message types, i found it added to Message::subEntities but not added to Message::getType.

I cannot confirm if there are more things forgotten.

I think it should be added, but i cannot confirm too.

If should not be added, please tell why.
