### PR TITLE
Feat: allow dynamic properties for PHP8.2

### DIFF
--- a/src/Entities/Entity.php
+++ b/src/Entities/Entity.php
@@ -24,6 +24,7 @@ use Longman\TelegramBot\Entities\InputMedia\InputMedia;
  * @method array  getRawData()     Get the raw data passed to this entity
  * @method string getBotUsername() Return the bot name passed to this entity
  */
+#[\AllowDynamicProperties]
 abstract class Entity implements \JsonSerializable
 {
 


### PR DESCRIPTION
Add `AllowDynamicProperties` attribute to Entities.php for PHP8.2 compatibility. Not a permanent/final solution, but good enough to allow upgrades.

#1375 