### PR TITLE
Allow using WebAppDataCommand to handle web_app_data updates

### DIFF
--- a/src/Telegram.php
+++ b/src/Telegram.php
@@ -581,7 +581,12 @@ class Telegram
      */
     protected function getCommandFromType(string $type): string
     {
-        return $this->ucFirstUnicode(str_replace('_', '', $type));
+        switch ($type) {
+            case 'web_app_data':
+                return $type;
+            default:
+                return $this->ucFirstUnicode(str_replace('_', '', $type));
+        }
     }
 
     /**


### PR DESCRIPTION
| ?            |  !
|---           | ---
| Type         | bug
| BC Break     | yes
| Fixed issues | #1423

#### Summary

This PR introduces a BC break if someone is using a command defined in a `WebAppDataCommand` class.
