### PR TITLE
Fix building TelegramException in getCommandsList()

### DIFF
--- a/src/Telegram.php
+++ b/src/Telegram.php
@@ -303,7 +303,7 @@ class Telegram
                     }
                 }
             } catch (Exception $e) {
-                throw new TelegramException('Error getting commands from path: ' . $path, $e);
+                throw new TelegramException('Error getting commands from path: ' . $path, $e->getCode(), $e);
             }
         }
 

--- a/src/Telegram.php
+++ b/src/Telegram.php
@@ -303,7 +303,7 @@ class Telegram
                     }
                 }
             } catch (Exception $e) {
-                throw new TelegramException('Error getting commands from path: ' . $path, $e->getCode(), $e);
+                throw new TelegramException('Error getting commands from path: ' . $path, 0, $e);
             }
         }
 


### PR DESCRIPTION
| ?            |  !
|---           | ---
| Type         | bug
| BC Break     | no
| Fixed issues | 

#### Summary

This fix the following TypeError:

Exception::__construct():
Argument #2 ($code) must be of type int, Exception given
