### PR TITLE
Fix PHP Error - Call to a member function getChat() on null

### DIFF
--- a/src/Commands/AdminCommands/ChatsCommand.php
+++ b/src/Commands/AdminCommands/ChatsCommand.php
@@ -53,7 +53,7 @@ class ChatsCommand extends AdminCommand
      */
     public function execute(): ServerResponse
     {
-        $message = $this->getMessage();
+        $message = $this->getMessage() ?: $this->getEditedMessage() ?: $this->getChannelPost() ?: $this->getEditedChannelPost();
 
         $chat_id = $message->getChat()->getId();
         $text    = trim($message->getText(true));

--- a/src/Commands/AdminCommands/CleanupCommand.php
+++ b/src/Commands/AdminCommands/CleanupCommand.php
@@ -365,7 +365,7 @@ class CleanupCommand extends AdminCommand
      */
     public function execute(): ServerResponse
     {
-        $message = $this->getMessage();
+        $message = $this->getMessage() ?: $this->getEditedMessage() ?: $this->getChannelPost() ?: $this->getEditedChannelPost();
         $text    = $message->getText(true);
 
         // Dry run?

--- a/src/Commands/AdminCommands/DebugCommand.php
+++ b/src/Commands/AdminCommands/DebugCommand.php
@@ -52,7 +52,7 @@ class DebugCommand extends AdminCommand
     public function execute(): ServerResponse
     {
         $pdo     = DB::getPdo();
-        $message = $this->getMessage();
+        $message = $this->getMessage() ?: $this->getEditedMessage() ?: $this->getChannelPost() ?: $this->getEditedChannelPost();
         $chat    = $message->getChat();
         $text    = strtolower($message->getText(true));
 

--- a/src/Commands/AdminCommands/SendtochannelCommand.php
+++ b/src/Commands/AdminCommands/SendtochannelCommand.php
@@ -63,7 +63,7 @@ class SendtochannelCommand extends AdminCommand
      */
     public function execute(): ServerResponse
     {
-        $message = $this->getMessage();
+        $message = $this->getMessage() ?: $this->getEditedMessage() ?: $this->getChannelPost() ?: $this->getEditedChannelPost();
         $chat_id = $message->getChat()->getId();
         $user_id = $message->getFrom()->getId();
 
@@ -359,7 +359,7 @@ class SendtochannelCommand extends AdminCommand
      */
     public function executeNoDb(): ServerResponse
     {
-        $message = $this->getMessage();
+        $message = $this->getMessage() ?: $this->getEditedMessage() ?: $this->getChannelPost() ?: $this->getEditedChannelPost();
         $text    = trim($message->getText(true));
 
         if ($text === '') {

--- a/src/Commands/AdminCommands/WhoisCommand.php
+++ b/src/Commands/AdminCommands/WhoisCommand.php
@@ -60,7 +60,7 @@ class WhoisCommand extends AdminCommand
      */
     public function execute(): ServerResponse
     {
-        $message = $this->getMessage();
+        $message = $this->getMessage() ?: $this->getEditedMessage() ?: $this->getChannelPost() ?: $this->getEditedChannelPost();
 
         $chat_id = $message->getChat()->getId();
         $command = $message->getCommand();

--- a/src/Commands/Command.php
+++ b/src/Commands/Command.php
@@ -184,7 +184,7 @@ abstract class Command
         }
 
         if ($this->isPrivateOnly() && $this->removeNonPrivateMessage()) {
-            $message = $this->getMessage();
+            $message = $this->getMessage() ?: $this->getEditedMessage() ?: $this->getChannelPost() ?: $this->getEditedChannelPost();
 
             if ($user = $message->getFrom()) {
                 return Request::sendMessage([

--- a/src/Commands/SystemCommand.php
+++ b/src/Commands/SystemCommand.php
@@ -53,7 +53,7 @@ abstract class SystemCommand extends Command
      */
     protected function executeActiveConversation(): ?ServerResponse
     {
-        $message = $this->getMessage();
+        $message = $this->getMessage() ?: $this->getEditedMessage() ?: $this->getChannelPost() ?: $this->getEditedChannelPost();
         if ($message === null) {
             return null;
         }
@@ -84,7 +84,7 @@ abstract class SystemCommand extends Command
      */
     protected function executeDeprecatedSystemCommand(): ?ServerResponse
     {
-        $message = $this->getMessage();
+        $message = $this->getMessage() ?: $this->getEditedMessage() ?: $this->getChannelPost() ?: $this->getEditedChannelPost();
         if ($message === null) {
             return null;
         }

--- a/src/Commands/UserCommands/StartCommand.php
+++ b/src/Commands/UserCommands/StartCommand.php
@@ -47,7 +47,7 @@ class StartCommand extends UserCommand
      */
     public function execute(): ServerResponse
     {
-        //$message = $this->getMessage();
+        //$message = $this->getMessage() ?: $this->getEditedMessage() ?: $this->getChannelPost() ?: $this->getEditedChannelPost();
         //$chat_id = $message->getChat()->getId();
         //$user_id = $message->getFrom()->getId();
 


### PR DESCRIPTION
<!--
Important:
If this pull request is not related to any issue and contains a new feature, please create an issue first for discussion.
https://github.com/php-telegram-bot/core/issues/new?template=Feature_Request.md

Make sure this pull request is pointed towards the "develop" branch and refers to any issue that it's related to!
-->

<!-- Fill in the relevant information below to help triage your pull request. -->

| ?            |  !
|---           | ---
| Type         | bug
| BC Break     | yes
| Fixed issues | #1456

#### Summary

in some case maybe users want to edit command and when the commend edited the `$this->getMessage()` return null and must use `$this->getEditedMessage()` to fix this issue
