### PR TITLE
Update 0.82.0-0.83.0.sql

### DIFF
--- a/utils/db-schema-update/0.82.0-0.83.0.sql
+++ b/utils/db-schema-update/0.82.0-0.83.0.sql
@@ -69,3 +69,9 @@ ALTER TABLE `message`
 ALTER TABLE `telegram_update`
     ADD COLUMN `message_reaction_id`       bigint UNSIGNED DEFAULT NULL COMMENT 'A reaction to a message was changed by a user' AFTER `edited_channel_post_id`,
     ADD COLUMN `message_reaction_count_id` bigint UNSIGNED DEFAULT NULL COMMENT 'Reactions to a message with anonymous reactions were changed' AFTER `message_reaction_id`;
+
+ALTER TABLE `telegram_update` ADD COLUMN `chat_boost_updated_id` BIGINT UNSIGNED NULL COMMENT 'A boost update the chat has been sent';
+ALTER TABLE `telegram_update` ADD FOREIGN KEY (`chat_boost_updated_id`) REFERENCES `chat_boost_updated` (`id`);
+
+ALTER TABLE `telegram_update` ADD COLUMN `chat_boost_removed_id` BIGINT UNSIGNED NULL COMMENT 'A boost remove from the chat has been sent';
+ALTER TABLE `telegram_update` ADD FOREIGN KEY (`chat_boost_removed_id`) REFERENCES `chat_boost_removed` (`id`);


### PR DESCRIPTION
Forgot to update schema to work with Boosts properly

<!--
Important:
If this pull request is not related to any issue and contains a new feature, please create an issue first for discussion.
https://github.com/php-telegram-bot/core/issues/new?template=Feature_Request.md

Make sure this pull request is pointed towards the "develop" branch and refers to any issue that it's related to!
-->

<!-- Fill in the relevant information below to help triage your pull request. -->

| ?            |  !
|---           | ---
| Type         | bug 
| BC Break     | yes / no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

<!-- Provide a summary of your change. -->
Always has a warnings in DB.php on every update.

[30-May-2024 02:00:33 UTC] PHP Warning:  PDOStatement::execute(): SQLSTATE[42S22]: Column not found: 1054 Unknown column 'chat_boost_updated_id' in 'field list' in /vendor/longman/telegram-bot/src/DB.php on line 404
[30-May-2024 02:00:33 UTC] PHP Stack trace:
[30-May-2024 02:00:33 UTC] PHP   1. {main}() /manager.php:0
[30-May-2024 02:00:33 UTC] PHP   2. TelegramBot\TelegramBotManager\BotManager->run() /manager.php:28
[30-May-2024 02:00:33 UTC] PHP   3. TelegramBot\TelegramBotManager\BotManager->handleRequest() /vendor/php-telegram-bot/telegram-bot-manager/src/BotManager.php:106
[30-May-2024 02:00:33 UTC] PHP   4. TelegramBot\TelegramBotManager\BotManager->handleWebhook() /vendor/php-telegram-bot/telegram-bot-manager/src/BotManager.php:266
[30-May-2024 02:00:33 UTC] PHP   5. Longman\TelegramBot\Telegram->handle() /vendor/php-telegram-bot/telegram-bot-manager/src/BotManager.php:418
[30-May-2024 02:00:33 UTC] PHP   6. Longman\TelegramBot\Telegram->processUpdate($update = class Longman\TelegramBot\Entities\Update { public $bot_username = 'some-bot'; public $raw_data = ['update_id' => 312745397, 'message' => [...]]; private ${Longman\TelegramBot\Entities\Entity}fields = ['update_id' => 312745397, 'message' => [...]] }) /vendor/longman/telegram-bot/src/Telegram.php:568
[30-May-2024 02:00:33 UTC] PHP   7. Longman\TelegramBot\DB::insertRequest($update = class Longman\TelegramBot\Entities\Update { public $bot_username = 'some-bot'; public $raw_data = ['update_id' => 312745397, 'message' => [...]]; private ${Longman\TelegramBot\Entities\Entity}fields = ['update_id' => 312745397, 'message' => [...]] }) /vendor/longman/telegram-bot/src/Telegram.php:655
[30-May-2024 02:00:33 UTC] PHP   8. Longman\TelegramBot\DB::insertTelegramUpdate($update_id = 312745397, $chat_id = -10000000000, $message_id = 000000, $edited_message_id = NULL, $channel_post_id = NULL, $edited_channel_post_id = NULL, $message_reaction_id = NULL, $message_reaction_count_id = NULL, $inline_query_id = NULL, $chosen_inline_result_id = NULL, $callback_query_id = NULL, $shipping_query_id = NULL, $pre_checkout_query_id = NULL, $poll_id = NULL, $poll_answer_poll_id = NULL, $my_chat_member_updated_id = NULL, $chat_member_updated_id = NULL, $chat_join_request_id = NULL, $chat_boost_updated_id = NULL, $chat_boost_removed_id = NULL) /vendor/longman/telegram-bot/src/DB.php:627
[30-May-2024 02:00:33 UTC] PHP   9. PDOStatement->execute() /vendor/longman/telegram-bot/src/DB.php:404

It seems just forgot to update schema