### PR TITLE
PHPDoc comment in MessageOriginChat mislead to wrong getter getChat().

### DIFF
--- a/src/Commands/AdminCommands/CleanupCommand.php
+++ b/src/Commands/AdminCommands/CleanupCommand.php
@@ -69,7 +69,7 @@ class CleanupCommand extends AdminCommand
      *
      * @var array
      */
-    protected static $default_tables_to_clean = [
+    protected static array $default_tables_to_clean = [
         'callback_query',
         'chosen_inline_result',
         'conversation',
@@ -85,7 +85,7 @@ class CleanupCommand extends AdminCommand
      *
      * @var array
      */
-    protected static $default_clean_older_than = [
+    protected static array $default_clean_older_than = [
         'callback_query'       => '30 days',
         'chat'                 => '365 days',
         'chosen_inline_result' => '30 days',
@@ -108,7 +108,7 @@ class CleanupCommand extends AdminCommand
      *
      * @return array
      */
-    private function getSettings($custom_time = ''): array
+    private function getSettings(string $custom_time = ''): array
     {
         $tables_to_clean      = self::$default_tables_to_clean;
         $user_tables_to_clean = $this->getConfig('tables_to_clean');
@@ -180,8 +180,24 @@ class CleanupCommand extends AdminCommand
                           )
                         )
                         OR (
+                          `channel_post_id` IS NOT NULL
+                          AND `channel_post_id` IN (
+                            SELECT `id`
+                            FROM `%5$s`
+                            WHERE `date` < \'%2$s\'
+                          )
+                        )
+                        OR (
                           `edited_message_id` IS NOT NULL
                           AND `edited_message_id` IN (
+                            SELECT `id`
+                            FROM `%6$s`
+                            WHERE `edit_date` < \'%2$s\'
+                          )
+                        )
+                        OR (
+                          `edited_channel_post_id` IS NOT NULL
+                          AND `edited_channel_post_id` IN (
                             SELECT `id`
                             FROM `%6$s`
                             WHERE `edit_date` < \'%2$s\'
@@ -369,7 +385,7 @@ class CleanupCommand extends AdminCommand
         $text    = $message->getText(true);
 
         // Dry run?
-        $dry_run = strpos($text, 'dry') !== false;
+        $dry_run = str_contains($text, 'dry');
         $text    = trim(str_replace('dry', '', $text));
 
         $settings = $this->getSettings($text);

--- a/src/DB.php
+++ b/src/DB.php
@@ -1293,8 +1293,8 @@ class DB
             } elseif ($forward_origin instanceof MessageOriginHiddenUser) {
                 $forward_sender_name = $forward_origin->getSenderUserName();
             } elseif ($forward_origin instanceof MessageOriginChat) {
-                self::insertChat($forward_origin->getChat());
-                $forward_from_chat = $forward_origin->getChat()->getId();
+                self::insertChat($forward_origin->getSender_chat());
+                $forward_from_chat = $forward_origin->getSender_chat()->getId();
                 $forward_signature = $forward_origin->getAuthorSignature();
             } elseif ($forward_origin instanceof MessageOriginChannel) {
                 self::insertChat($forward_origin->getChat());

--- a/src/DB.php
+++ b/src/DB.php
@@ -1293,8 +1293,8 @@ class DB
             } elseif ($forward_origin instanceof MessageOriginHiddenUser) {
                 $forward_sender_name = $forward_origin->getSenderUserName();
             } elseif ($forward_origin instanceof MessageOriginChat) {
-                self::insertChat($forward_origin->getSender_chat());
-                $forward_from_chat = $forward_origin->getSender_chat()->getId();
+                self::insertChat($forward_origin->getSenderChat());
+                $forward_from_chat = $forward_origin->getSenderChat()->getId();
                 $forward_signature = $forward_origin->getAuthorSignature();
             } elseif ($forward_origin instanceof MessageOriginChannel) {
                 self::insertChat($forward_origin->getChat());

--- a/src/Entities/MessageOrigin/MessageOriginChat.php
+++ b/src/Entities/MessageOrigin/MessageOriginChat.php
@@ -12,7 +12,7 @@ use Longman\TelegramBot\Entities\Entity;
  *
  * @method string getType()            Type of the message origin, always “chat”
  * @method int    getDate()            Date the message was sent originally in Unix time
- * @method Chat   getSender_chat()            Chat that sent the message originally
+ * @method Chat   getSenderChat()            Chat that sent the message originally
  * @method string getAuthorSignature() Optional. For messages originally sent by an anonymous chat administrator, original message author signature
  */
 class MessageOriginChat extends Entity implements MessageOrigin

--- a/src/Entities/MessageOrigin/MessageOriginChat.php
+++ b/src/Entities/MessageOrigin/MessageOriginChat.php
@@ -12,7 +12,7 @@ use Longman\TelegramBot\Entities\Entity;
  *
  * @method string getType()            Type of the message origin, always “chat”
  * @method int    getDate()            Date the message was sent originally in Unix time
- * @method Chat   getChat()            Chat that sent the message originally
+ * @method Chat   getSender_chat()            Chat that sent the message originally
  * @method string getAuthorSignature() Optional. For messages originally sent by an anonymous chat administrator, original message author signature
  */
 class MessageOriginChat extends Entity implements MessageOrigin


### PR DESCRIPTION
Factory creates getter getSender_chat() because property name sender_chat in MessageOriginChat

<!--
Important:
If this pull request is not related to any issue and contains a new feature, please create an issue first for discussion.
https://github.com/php-telegram-bot/core/issues/new?template=Feature_Request.md

Make sure this pull request is pointed towards the "develop" branch and refers to any issue that it's related to!
-->

<!-- Fill in the relevant information below to help triage your pull request. -->

| ?            |  !
|---           | ---
| Type         | bug
| BC Break     | yes / no
| Fixed issues |  New. 

#### Summary
 
Just simple quick fix because PHPDoc Comment was the same to MessageOriginChat and MessageOriginChannel but properties isn't
