### PR TITLE
[-] Duplicate Class Declaration Error with Commands Matching Message …

### DIFF
--- a/src/Telegram.php
+++ b/src/Telegram.php
@@ -347,7 +347,7 @@ class Telegram
 
         $command_class = $command_namespace . '\\' . $this->commandNameToClassName($command);
 
-        if (class_exists($command_class)) {
+        if (class_exists($command_class, false)) {
             return $command_class;
         }
 


### PR DESCRIPTION
| ?            |  !
|---           | ---
| Type         | bug
| BC Break     | no
| Fixed issues | 1481

#### Summary

Duplicate Class Declaration Error with Commands Matching Message Types (e.g., LocationCommand) fixed by adding false to class_exists call. 
